### PR TITLE
feat: WinFsp RO/RW mount, auto-mount watcher, MSI installer, shared test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 *.swp
 .DS_Store
+.test-env
+test-diagnostics/
+.claude/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "harness"]
+	path = harness
+	url = https://github.com/antimatter-studios/fs-test-harness.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,8 +757,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 [[package]]
 name = "winfsp"
 version = "0.12.4+winfsp-2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51325fc20d218567a903cd5c382ad7d5a765f6860043f9c7d9ee1e907c5b75f6"
 dependencies = [
  "bytemuck",
  "parking_lot",
@@ -773,8 +771,6 @@ dependencies = [
 [[package]]
 name = "winfsp-sys"
 version = "0.12.1+winfsp-2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d42acc30c105f8d33507f556398237c738b681271c775a3b94eefd29d2b8c77e"
 dependencies = [
  "bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,19 @@ anyhow = "1"
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
+    "Win32_Graphics_Gdi",
     "Win32_Storage_FileSystem",
     "Win32_System_IO",
     "Win32_System_Ioctl",
+    "Win32_System_LibraryLoader",
+    "Win32_System_Threading",
     "Win32_Security",
+    "Win32_UI_WindowsAndMessaging",
 ] }
+# `watch` subcommand uses ctrlc on Windows. Pulled in unconditionally on
+# Windows so `watch` builds without the `mount` feature; on non-Windows
+# targets `watch` is a stub and ctrlc isn't needed.
+ctrlc = "3"
 # WinFsp + helpers. Optional + Windows-target-only — pulled in when the
 # `mount` feature is enabled AND the build target is Windows. On macOS
 # the `mount` feature does nothing (the cfg-gated module is empty).
@@ -41,7 +49,6 @@ windows = { version = "0.61", features = [
 ], optional = true }
 winfsp-sys = { path = "../winfsp-rs/winfsp-sys", optional = true }
 widestring = { version = "1", optional = true }
-ctrlc = { version = "3", optional = true }
 
 [target.'cfg(windows)'.build-dependencies]
 # Only used when the `mount` feature is on; build.rs guards the call.
@@ -53,7 +60,7 @@ default = []
 # Enables the `mount` subcommand (WinFsp driver). Active only on Windows
 # — on other targets the deps don't resolve and the cfg-gated code is
 # absent.
-mount = ["dep:winfsp", "dep:winfsp-sys", "dep:windows", "dep:widestring", "dep:ctrlc"]
+mount = ["dep:winfsp", "dep:winfsp-sys", "dep:windows", "dep:widestring"]
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -82,25 +82,38 @@ cargo build --release --features mount
 
 Scenarios live in [`test-matrix.json`](./test-matrix.json) and the per-project
 adapter config in [`harness.toml`](./harness.toml). Both are consumed by the
-shared [`fs-test-harness`](../fs-test-harness/) (sibling repo for now;
-submodule once we tag a release).
+shared [`fs-test-harness`](https://github.com/antimatter-studios/fs-test-harness)
+vendored as a git submodule at [`harness/`](./harness).
 
-One-time setup, on the Mac:
+After cloning, initialise the submodule:
 
 ```sh
-bash ../fs-test-harness/scripts/setup-local.sh        # writes .test-env
+git submodule update --init --recursive
+```
+
+One-time VM setup, on the Mac:
+
+```sh
+bash harness/scripts/setup-local.sh        # writes .test-env
 ```
 
 Run a scenario end-to-end (Mac → SSH → Windows VM → diag pull):
 
 ```sh
-bash ../fs-test-harness/scripts/test-windows-matrix.sh basic-ro-list
+bash harness/scripts/test-windows-matrix.sh basic-ro-list
 ```
 
 Diagnostics land under `test-diagnostics/run-<UTC>/`. See the harness's
-[`docs/triage-protocol.md`](../fs-test-harness/docs/triage-protocol.md) for
-how to read a failure, and [`docs/multi-agent-protocol.md`](../fs-test-harness/docs/multi-agent-protocol.md)
+[`docs/triage-protocol.md`](./harness/docs/triage-protocol.md) for how to
+read a failure, and [`docs/multi-agent-protocol.md`](./harness/docs/multi-agent-protocol.md)
 for running multiple agents against the same matrix.
+
+To update the harness when the upstream releases:
+
+```sh
+git submodule update --remote --merge harness
+git add harness && git commit -m "chore: bump harness submodule"
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,30 @@ cargo build --release --features mount
   - LLVM-MinGW (`winget install MartinStorsjo.LLVM-MinGW.UCRT`)
 - `LIBCLANG_PATH=C:\Program Files\LLVM\bin` so bindgen can find `libclang.dll`.
 
+## Testing
+
+Scenarios live in [`test-matrix.json`](./test-matrix.json) and the per-project
+adapter config in [`harness.toml`](./harness.toml). Both are consumed by the
+shared [`fs-test-harness`](../fs-test-harness/) (sibling repo for now;
+submodule once we tag a release).
+
+One-time setup, on the Mac:
+
+```sh
+bash ../fs-test-harness/scripts/setup-local.sh        # writes .test-env
+```
+
+Run a scenario end-to-end (Mac → SSH → Windows VM → diag pull):
+
+```sh
+bash ../fs-test-harness/scripts/test-windows-matrix.sh basic-ro-list
+```
+
+Diagnostics land under `test-diagnostics/run-<UTC>/`. See the harness's
+[`docs/triage-protocol.md`](../fs-test-harness/docs/triage-protocol.md) for
+how to read a failure, and [`docs/multi-agent-protocol.md`](../fs-test-harness/docs/multi-agent-protocol.md)
+for running multiple agents against the same matrix.
+
 ## License
 
 GPL-3.0 — inherited from the WinFsp Rust bindings. The CLI alone (without the

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ crate is the distribution unit.
 - [x] `--part N` mounts a partition slice via the C ABI's callback mount
 - [x] Win32 raw-device support (`\\.\X:`, `\\.\PhysicalDriveN`)
 - [x] **WinFsp read-only mount** — verified end-to-end on Windows 11 ARM64
-- [ ] WinFsp read-write mount
+- [x] **WinFsp read-write mount** (`--rw`) — create/write/truncate/rename/
+      unlink/rmdir/mkdir/utimens wired through to the C ABI. v1 caveat:
+      `write` round-trips the whole file (the underlying ABI is a "save-as"
+      replace), so large-file workloads are slow until a positional
+      `pwrite` lands in `fs-ext4`.
 - [ ] MSI installer (bundles WinFsp)
 
 ## Usage
@@ -42,7 +46,8 @@ ext4 ls     <whole-disk.img> --part 1 /    # browse partition 1
 WinFsp mount (Windows + `mount` feature):
 
 ```
-ext4 mount <image> --drive X:
+ext4 mount <image> --drive X:           # read-only (default)
+ext4 mount <image> --drive X: --rw      # read-write
 ```
 
 Then browse `X:` in Explorer, or `Get-ChildItem X:\`, etc. Ctrl-C to unmount.

--- a/docs/post-verify-hook.md
+++ b/docs/post-verify-hook.md
@@ -1,0 +1,142 @@
+# Post-verify hook for ext4-win-driver
+
+Status: **not implemented**. Tracked here + via the
+`audit-post-verify-marker` scenario in `test-matrix.json` (status
+`blocked-needs-audit-cli`).
+
+This doc records the design so the next agent who picks it up does not
+have to re-derive it. Three architectures are viable; option (c) is the
+cheapest near-term win.
+
+## What the harness already supports
+
+The shared `fs-test-harness` runner (see
+`../fs-test-harness/scripts/run-scenario.ps1`, stage E) already wires a
+post-verify hook through the matrix. There is nothing to change in the
+harness — the consumer just has to populate two fields:
+
+1. **`harness.toml [post_verify]`** — default command for every scenario
+   that does not override it.
+2. **Per-scenario `post_verify` block** — override or opt-in for a
+   specific scenario.
+
+The schema (`../fs-test-harness/schemas/test-matrix.schema.json`)
+defines:
+
+```json
+"post_verify": {
+  "command":     "<template, with {image} and {drive} substitution>",
+  "expect_exit": 0
+}
+```
+
+`run-scenario.ps1` runs this command **after** stage D (mount teardown)
+and **only** when the scenario otherwise passed. Output is captured to
+`post-verify-stdout.txt` / `post-verify-stderr.txt` under the diag
+directory; non-zero exit (or mismatch with `expect_exit`) flips the
+verdict from `passed` to `failed`.
+
+So the missing piece is purely "what command do we run."
+
+## Why we don't currently invoke `fsck.ext4`
+
+Two friction points block the obvious choice:
+
+- `fsck.ext4` is **not on the Windows VM** that runs scenarios. e2fsprogs
+  is a Linux-native package; on Windows it would have to come via WSL or
+  a hand-built MSYS2 / Cygwin port, both of which add a non-trivial
+  dependency to every contributor's VM.
+- Even if installed, the post-mount image lives on the VM's disk inside
+  `harness.toml [vm.workdir]`. `fsck.ext4` would need direct file-mode
+  access to the image after WinFsp has fully released it. WinFsp on
+  forced-teardown can leave the host process in TIME_WAIT briefly, so
+  this is not a blocker but it is a sequencing concern.
+
+## Two viable "real fsck" architectures
+
+### (a) Mac-side `fsck.ext4 -fn` after diag pull
+
+Workflow:
+
+1. The Windows VM finishes the scenario, leaves the post-RW image in
+   `vm.workdir`.
+2. `scripts/test-windows-matrix.sh` (Mac orchestrator) `scp`s the image
+   back to the Mac.
+3. Mac runs `fsck.ext4 -fn <image>` (Homebrew `e2fsprogs`,
+   `brew install e2fsprogs`; the binary lives at
+   `/opt/homebrew/opt/e2fsprogs/sbin/fsck.ext4`).
+4. Verdict is added to the diag bundle and reported alongside the
+   scenario's runner verdict.
+
+Pros: real upstream `fsck.ext4`, runs Mac-side so no VM bloat. Cons:
+**doesn't fit the harness's stage-E hook** — that runs on the VM, not
+the orchestrator. Implementing this means a separate "post-pull verify"
+step in `test-windows-matrix.sh`, not a `[post_verify]` template. It
+also requires every contributor to have e2fsprogs installed locally.
+
+### (b) Sidecar Linux container/VM accessible from the Mac orchestrator
+
+Workflow:
+
+1. Mac orchestrator pulls the post-RW image (same as option a).
+2. Hands the image to a small Linux VM (Lima, OrbStack, qemu-user-static
+   container, etc.).
+3. That VM runs `fsck.ext4 -fn` and returns exit code + log.
+
+Pros: hermetic, deterministic, identical fsck binary across
+contributors. Cons: significant infrastructure — adds a VM/container
+dependency to bootstrap. Same architectural mismatch as (a): not a
+`[post_verify]` template, lives in the orchestrator script.
+
+### (c) Interim: extend ext4-win-driver itself with an `audit` subcommand
+
+This is the cheapest near-term option and the one we are tracking.
+
+The underlying `rust-fs-ext4` library already exposes a read-only audit:
+see `Filesystem::audit` in `../rust-fs-ext4/src/fsck.rs` (around line
+446). It is a subset of `e2fsck` — walks the inode/extent/dir-block
+tree and surfaces structural anomalies. Not as thorough as upstream
+`fsck.ext4`, but cheap, in-tree, and runs on Windows because
+`rust-fs-ext4` is pure Rust.
+
+Once a tiny `ext4 audit <image>` clap subcommand is added to
+`src/main.rs` that wraps `Filesystem::audit(...)` and exits non-zero on
+any reported anomaly, the post-verify hook is a one-liner in
+`harness.toml`:
+
+```toml
+[post_verify]
+command     = "{binary} audit {image}"
+expect_exit = 0
+```
+
+That's it. The harness already does the rest — runs the command after
+mount teardown, captures output, flips the verdict on non-zero exit.
+
+The matrix scenario `audit-post-verify-marker` (status
+`blocked-needs-audit-cli`) carries the per-scenario shape of the same
+hook for reviewers re-reading the matrix later:
+
+```json
+"post_verify": {
+  "command": "{binary} audit {image}",
+  "expect_exit": 0
+}
+```
+
+When the `audit` subcommand lands, three follow-up edits unblock the
+hook:
+
+1. Add `[post_verify]` block above to `harness.toml`.
+2. Flip `audit-post-verify-marker.status` from `blocked-needs-audit-cli`
+   to `pending`.
+3. Decide whether every RW scenario should inherit the global
+   `[post_verify]` (probably yes).
+
+## Why this is parked, not done now
+
+The task that produced this doc explicitly carved the `audit` CLI out
+as a follow-up commit ("Do not add any new CLI subcommand to
+ext4-win-driver in this commit. The `audit` command is an explicit
+follow-up; document it without implementing."). This file plus the
+marker scenario keep the design visible until that follow-up lands.

--- a/fixtures/build-whole-disk.py
+++ b/fixtures/build-whole-disk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Wrap ext4-basic.img in a synthetic GPT-partitioned whole-disk image.
+
+The harness scenario `whole-disk-with-part` exercises `ext4 mount
+<image> --part 1`, which needs a disk image with an ext4 partition
+inside an MBR/GPT layout. We synthesise the smallest valid GPT we can
+get away with: protective MBR at LBA 0, GPT header at LBA 1,
+single-entry partition array at LBA 2, ext4 payload starting at the
+standard 1-MiB-aligned LBA 2048.
+
+Re-run whenever `ext4-basic.img` changes:
+
+    python3 fixtures/build-whole-disk.py
+"""
+import struct
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = REPO.parent / "rust-fs-ext4" / "test-disks" / "ext4-basic.img"
+DST = REPO.parent / "rust-fs-ext4" / "test-disks" / "ext4-whole-disk.img"
+
+SECTOR = 512
+DATA_LBA = 2048
+
+# Linux filesystem data partition type GUID, on-disk byte order
+# (mixed-endian: data1+data2+data3 little-endian, data4 big-endian).
+GUID_LINUX_FS = bytes(
+    [0xAF, 0xDA, 0xC6, 0x0F, 0x83, 0x84, 0x72, 0x47,
+     0x8E, 0x79, 0x3D, 0x69, 0xD8, 0x47, 0x7D, 0xE4]
+)
+
+
+def main() -> int:
+    if not SRC.exists():
+        print(f"missing source: {SRC}", file=sys.stderr)
+        return 1
+    data = SRC.read_bytes()
+    data_sectors = (len(data) + SECTOR - 1) // SECTOR
+    total_sectors = DATA_LBA + data_sectors + 64  # backup-GPT pad
+    img = bytearray(total_sectors * SECTOR)
+
+    # Protective MBR.
+    img[510] = 0x55
+    img[511] = 0xAA
+    mbr_part = 446
+    img[mbr_part + 4] = 0xEE
+    img[mbr_part + 8 : mbr_part + 12] = struct.pack("<I", 1)
+    img[mbr_part + 12 : mbr_part + 16] = struct.pack(
+        "<I", min(0xFFFFFFFF, total_sectors - 1)
+    )
+
+    # GPT header at LBA 1 (CRCs left zeroed — our parser doesn't verify).
+    hdr = bytearray(92)
+    hdr[0:8] = b"EFI PART"
+    hdr[12:16] = struct.pack("<I", 92)        # header_size
+    hdr[72:80] = struct.pack("<Q", 2)         # part array LBA
+    hdr[80:84] = struct.pack("<I", 1)         # n entries
+    hdr[84:88] = struct.pack("<I", 128)       # entry size
+    img[SECTOR : SECTOR + 92] = hdr
+
+    # Single partition entry at LBA 2.
+    entry = bytearray(128)
+    entry[0:16] = GUID_LINUX_FS
+    entry[32:40] = struct.pack("<Q", DATA_LBA)
+    entry[40:48] = struct.pack("<Q", DATA_LBA + data_sectors - 1)
+    for i, ch in enumerate("rootfs"):
+        entry[56 + i * 2 : 56 + i * 2 + 2] = struct.pack("<H", ord(ch))
+    img[SECTOR * 2 : SECTOR * 2 + 128] = entry
+
+    # Embed the ext4 image.
+    img[DATA_LBA * SECTOR : DATA_LBA * SECTOR + len(data)] = data
+
+    DST.write_bytes(img)
+    print(f"wrote {DST}: {len(img):,} bytes ({total_sectors:,} sectors)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/harness.toml
+++ b/harness.toml
@@ -1,0 +1,48 @@
+# harness.toml — fs-test-harness consumer config for ext4-win-driver.
+#
+# The harness scripts + Rust runner live at ../fs-test-harness. Once
+# fs-test-harness is published, switch to a `harness/` git submodule and
+# update the paths in CONTRIBUTING / docs accordingly.
+
+[project]
+name        = "ext4-win-driver"
+binary      = "target/release/ext4.exe"
+matrix_path = "test-matrix.json"
+
+[vm]
+host           = "chris@192.168.213.145"
+ssh_key        = "../diskjockey/vendor/rust-fs-ntfs/privatekey"
+workdir        = "C:/Users/chris/dev/ext4-work"
+image_dir      = "../rust-fs-ext4/test-disks"
+rust_toolchain = "stable-aarch64-pc-windows-gnullvm"
+# winfsp + LLVM-MinGW + LLVM (libclang) are prerequisites; see README's
+# "WinFsp build prerequisites" section. setup-windows-vm.ps1 handles
+# the rustup pieces; the user installs WinFsp + LLVM via winget once.
+packages = [
+    "MartinStorsjo.LLVM-MinGW.UCRT",
+    "LLVM.LLVM",
+]
+# bindgen needs libclang to parse winfsp.h.
+env_prefix = "$env:LIBCLANG_PATH = 'C:\\Program Files\\LLVM\\bin'"
+
+[tools]
+# Optional. fsck.ext4 isn't on the Windows VM today; post-verify hooks
+# referencing {tools.fsck} are stubbed out via [post_verify] until we
+# wire a Mac-side post-pull fsck into test-windows-matrix.sh.
+# fsck = "fsck.ext4 -fn"
+
+[ops]
+ls   = "{binary} ls   {image} {path}"
+cat  = "{binary} cat  {image} {path}"
+stat = "{binary} stat {image} {path}"
+tree = "{binary} tree {image}"
+# `parts` is ext4-win-driver-specific.
+parts = "{binary} parts {image}"
+
+[mount]
+# WinFsp mount, foreground. The runner kills the background process on
+# scenario teardown; ready_line tells the harness when to start running
+# scenario ops against the live mount.
+command    = "{binary} mount {image} --drive {drive} {extra}"
+ready_line = "ext4 mounted at"
+rw_extra   = "--rw"

--- a/harness.toml
+++ b/harness.toml
@@ -23,7 +23,7 @@ packages = [
     "LLVM.LLVM",
 ]
 # bindgen needs libclang to parse winfsp.h.
-env_prefix = "$env:LIBCLANG_PATH = 'C:\\Program Files\\LLVM\\bin'"
+env_prefix = "$env:LIBCLANG_PATH = 'C:\\Program Files\\LLVM\\bin';"
 
 [tools]
 # Optional. fsck.ext4 isn't on the Windows VM today; post-verify hooks

--- a/harness.toml
+++ b/harness.toml
@@ -1,8 +1,8 @@
 # harness.toml — fs-test-harness consumer config for ext4-win-driver.
 #
-# The harness scripts + Rust runner live at ../fs-test-harness. Once
-# fs-test-harness is published, switch to a `harness/` git submodule and
-# update the paths in CONTRIBUTING / docs accordingly.
+# The harness scripts + Rust runner live at ./harness/, vendored as a
+# git submodule from https://github.com/antimatter-studios/fs-test-harness.
+# Run `git submodule update --init --recursive` after cloning.
 
 [project]
 name        = "ext4-win-driver"

--- a/harness.toml
+++ b/harness.toml
@@ -32,12 +32,15 @@ env_prefix = "$env:LIBCLANG_PATH = 'C:\\Program Files\\LLVM\\bin';"
 # fsck = "fsck.ext4 -fn"
 
 [ops]
-ls   = "{binary} ls   {image} {path}"
-cat  = "{binary} cat  {image} {path}"
-stat = "{binary} stat {image} {path}"
-tree = "{binary} tree {image}"
-# `parts` is ext4-win-driver-specific.
+# {extra} carries per-op CLI flags (e.g. `--part 1` for whole-disk
+# images). Empty by default; set per scenario via the op's `extra`
+# field.
+ls   = "{binary} ls   {image} {path} {extra}"
+cat  = "{binary} cat  {image} {path} {extra}"
+stat = "{binary} stat {image} {path} {extra}"
+tree = "{binary} tree {image} {extra}"
 parts = "{binary} parts {image}"
+info  = "{binary} info  {image}"
 
 [mount]
 # WinFsp mount, foreground. The runner kills the background process on

--- a/installer/Mount-Ext4.ps1
+++ b/installer/Mount-Ext4.ps1
@@ -1,0 +1,113 @@
+<#
+.SYNOPSIS
+  Mount an ext4 image as a Windows drive letter via WinFsp.
+
+.DESCRIPTION
+  Thin PowerShell wrapper around `ext4.exe mount`. Accepts an optional
+  image path; if omitted, opens an Open-File dialog so the user can pick
+  one. Picks the first free drive letter (Z:..D:) and runs the mount in
+  the foreground — Ctrl-C unmounts.
+
+  Installed alongside ext4.exe in `%ProgramFiles%\ext4-win-driver\`.
+
+.PARAMETER ImagePath
+  Path to an ext4 image (.img) or whole-disk image. Optional.
+
+.PARAMETER DriveLetter
+  Force a specific drive letter (e.g. 'X:'). Optional. Default: first free.
+
+.PARAMETER Part
+  1-indexed partition number for whole-disk images. Optional.
+
+.EXAMPLE
+  Mount-Ext4.ps1 C:\images\rootfs.img
+  Mount-Ext4.ps1 -ImagePath disk.img -DriveLetter Y: -Part 1
+  Mount-Ext4.ps1                                # opens file picker
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [string]$ImagePath,
+
+    [Parameter()]
+    [string]$DriveLetter,
+
+    [Parameter()]
+    [int]$Part
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ----------------------------------------------------------------------------
+# Locate ext4.exe. Installed copy lives next to this script in Program Files;
+# fall back to PATH for dev runs.
+# ----------------------------------------------------------------------------
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$exeNextToScript = Join-Path $scriptDir 'ext4.exe'
+
+if (Test-Path $exeNextToScript) {
+    $ext4Exe = $exeNextToScript
+} else {
+    $cmd = Get-Command ext4.exe -ErrorAction SilentlyContinue
+    if (-not $cmd) {
+        Write-Error "ext4.exe not found next to this script ($scriptDir) or on PATH."
+        exit 1
+    }
+    $ext4Exe = $cmd.Source
+}
+
+# ----------------------------------------------------------------------------
+# If no image path was supplied, pop the Open-File dialog.
+# ----------------------------------------------------------------------------
+if (-not $ImagePath) {
+    Add-Type -AssemblyName System.Windows.Forms
+    $dlg = New-Object System.Windows.Forms.OpenFileDialog
+    $dlg.Title = 'Select an ext4 image to mount'
+    $dlg.Filter = 'Disk images (*.img;*.iso;*.bin;*.raw)|*.img;*.iso;*.bin;*.raw|All files (*.*)|*.*'
+    $dlg.CheckFileExists = $true
+    if ($dlg.ShowDialog() -ne [System.Windows.Forms.DialogResult]::OK) {
+        Write-Host 'Cancelled.'
+        exit 0
+    }
+    $ImagePath = $dlg.FileName
+}
+
+if (-not (Test-Path $ImagePath)) {
+    Write-Error "Image not found: $ImagePath"
+    exit 1
+}
+
+# ----------------------------------------------------------------------------
+# Pick a drive letter if the user didn't supply one. Walk Z..D and grab the
+# first letter that isn't currently a PSDrive.
+# ----------------------------------------------------------------------------
+function Get-FreeDriveLetter {
+    $used = @(Get-PSDrive -PSProvider FileSystem | ForEach-Object { $_.Name.ToUpper() })
+    foreach ($c in [char[]]'ZYXWVUTSRQPONMLKJIHGFED') {
+        if ($used -notcontains "$c") { return "${c}:" }
+    }
+    throw 'No free drive letter available (D..Z all in use).'
+}
+
+if (-not $DriveLetter) {
+    $DriveLetter = Get-FreeDriveLetter
+}
+
+# Normalise: 'X' -> 'X:'.
+if ($DriveLetter -notmatch ':$') { $DriveLetter += ':' }
+
+# ----------------------------------------------------------------------------
+# Run the mount in the foreground. Ctrl-C in the console unmounts.
+# ----------------------------------------------------------------------------
+$args = @('mount', $ImagePath, '--drive', $DriveLetter)
+if ($PSBoundParameters.ContainsKey('Part')) {
+    $args += @('--part', "$Part")
+}
+
+Write-Host "Mounting $ImagePath at $DriveLetter ..."
+Write-Host "Ctrl-C in this window to unmount."
+Write-Host ""
+
+& $ext4Exe @args
+exit $LASTEXITCODE

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ext4-win-driver MSI source — WiX 4+.
+
+  Build via `installer/build.ps1` (which shells out to `wix build`).
+  The build script passes:
+    -d ExePath=<path to ext4.exe>     (PATH to the release binary)
+    -d Version=<x.y.z>                (from Cargo.toml; default 0.1.0)
+
+  Stable UpgradeCode — DO NOT regenerate on every build, or major-upgrade
+  detection breaks. Generated as a v4 UUID for this product line.
+-->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui"
+     xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+
+  <Package
+      Name="ext4-win-driver"
+      Manufacturer="Chris Thomas"
+      Version="$(var.Version)"
+      UpgradeCode="d6f3a7c2-9b14-4e7a-9b23-7c5f1f4a8e91"
+      Scope="perMachine"
+      Compressed="yes"
+      InstallerVersion="500">
+
+    <SummaryInformation
+        Description="ext4-win-driver — browse and mount ext4 volumes on Windows"
+        Manufacturer="Chris Thomas" />
+
+    <MediaTemplate EmbedCab="yes" />
+
+    <!-- Major upgrade: silently uninstall older versions. -->
+    <MajorUpgrade DowngradeErrorMessage="A newer version of ext4-win-driver is already installed." />
+
+    <!--
+      WinFsp detection. WinFsp's installer writes
+        HKLM\SOFTWARE\WOW6432Node\WinFsp\InstallDir       (32-bit view, primary)
+        HKLM\SOFTWARE\WinFsp\InstallDir                    (64-bit view, fallback)
+      If neither is present we abort with a friendly message.
+    -->
+    <Property Id="WINFSPINSTALLDIR">
+      <RegistrySearch
+          Id="FindWinFspInstallDir32"
+          Root="HKLM"
+          Key="SOFTWARE\WOW6432Node\WinFsp"
+          Name="InstallDir"
+          Type="raw"
+          Bitness="always32" />
+    </Property>
+    <Property Id="WINFSPINSTALLDIR64">
+      <RegistrySearch
+          Id="FindWinFspInstallDir64"
+          Root="HKLM"
+          Key="SOFTWARE\WinFsp"
+          Name="InstallDir"
+          Type="raw"
+          Bitness="always64" />
+    </Property>
+
+    <!--
+      LaunchCondition: at least one of the two InstallDir values must be present.
+      Message is shown in the standard MSI error dialog; the URL is plain text
+      because LaunchCondition messages don't render hyperlinks.
+    -->
+    <Launch
+        Condition="WINFSPINSTALLDIR OR WINFSPINSTALLDIR64 OR Installed"
+        Message="WinFsp 2.x is required but was not found. Please install WinFsp from https://winfsp.dev/ and then re-run this installer." />
+
+    <Feature Id="Main" Title="ext4-win-driver" Level="1">
+      <ComponentGroupRef Id="ProductComponents" />
+      <ComponentGroupRef Id="ContextMenuComponents" />
+      <ComponentGroupRef Id="StartMenuComponents" />
+    </Feature>
+
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLFOLDER" Name="ext4-win-driver" />
+    </StandardDirectory>
+
+    <StandardDirectory Id="ProgramMenuFolder">
+      <Directory Id="ApplicationProgramsFolder" Name="ext4-win-driver" />
+    </StandardDirectory>
+
+    <!-- ====================================================================
+         Main payload: ext4.exe, the helper PowerShell script, the LICENSE.
+         ==================================================================== -->
+    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+
+      <Component Id="Ext4Exe" Guid="*">
+        <File
+            Id="Ext4ExeFile"
+            Source="$(var.ExePath)"
+            KeyPath="yes"
+            Name="ext4.exe" />
+        <!--
+          PATH update via WixUtilExtension. System=yes writes to the machine
+          PATH (we're a perMachine install). Action=set + Part=last appends
+          INSTALLFOLDER. The element is automatically reversed on uninstall.
+        -->
+        <Environment
+            Id="PathEnv"
+            Name="PATH"
+            Value="[INSTALLFOLDER]"
+            Permanent="no"
+            Part="last"
+            Action="set"
+            System="yes" />
+      </Component>
+
+      <Component Id="MountScript" Guid="*">
+        <File
+            Id="MountScriptFile"
+            Source="Mount-Ext4.ps1"
+            KeyPath="yes"
+            Name="Mount-Ext4.ps1" />
+      </Component>
+
+      <Component Id="LicenseFile" Guid="*">
+        <File
+            Id="LicenseFileF"
+            Source="LICENSE"
+            KeyPath="yes"
+            Name="LICENSE.txt" />
+      </Component>
+
+    </ComponentGroup>
+
+    <!-- ====================================================================
+         Explorer right-click context menu on .img files.
+
+         We attach to SystemFileAssociations\.img (a verb-only key that doesn't
+         override the user's default association — Disk Management's built-in
+         Mount verb keeps working for VHD/ISO).
+
+         Components live under INSTALLFOLDER so KeyPath can sit on a registry
+         value. Each Component MUST have exactly one KeyPath.
+         ==================================================================== -->
+    <ComponentGroup Id="ContextMenuComponents" Directory="INSTALLFOLDER">
+
+      <Component Id="ContextMenuVerb" Guid="*">
+        <RegistryKey Root="HKCR" Key="SystemFileAssociations\.img\shell\MountAsExt4">
+          <RegistryValue
+              Type="string"
+              Value="Mount as ext4"
+              KeyPath="yes" />
+          <RegistryValue
+              Name="Icon"
+              Type="string"
+              Value="&quot;[INSTALLFOLDER]ext4.exe&quot;" />
+        </RegistryKey>
+      </Component>
+
+      <Component Id="ContextMenuCommand" Guid="*">
+        <RegistryKey Root="HKCR" Key="SystemFileAssociations\.img\shell\MountAsExt4\command">
+          <RegistryValue
+              Type="string"
+              Value="powershell.exe -NoExit -ExecutionPolicy Bypass -File &quot;[INSTALLFOLDER]Mount-Ext4.ps1&quot; &quot;%1&quot;"
+              KeyPath="yes" />
+        </RegistryKey>
+      </Component>
+
+    </ComponentGroup>
+
+    <!-- ====================================================================
+         Start Menu shortcuts.
+
+         Per-user state is captured via a HKCU registry KeyPath sentinel —
+         that's the canonical way to give a per-machine install a per-user
+         shortcut component (otherwise ICE38/ICE43 fire).
+         ==================================================================== -->
+    <ComponentGroup Id="StartMenuComponents" Directory="ApplicationProgramsFolder">
+
+      <Component Id="StartMenuShortcuts" Guid="*">
+        <Shortcut
+            Id="MountImgShortcut"
+            Name="Mount ext4 image..."
+            Description="Pick an ext4 .img file and mount it as a Windows drive letter."
+            Target="powershell.exe"
+            Arguments="-NoExit -ExecutionPolicy Bypass -File &quot;[INSTALLFOLDER]Mount-Ext4.ps1&quot;"
+            WorkingDirectory="INSTALLFOLDER"
+            Icon="ext4Icon.exe"
+            IconIndex="0" />
+        <Shortcut
+            Id="WatchShortcut"
+            Name="ext4 watch service"
+            Description="Run the ext4 watch service in a console (Ctrl-C to stop)."
+            Target="[INSTALLFOLDER]ext4.exe"
+            Arguments="watch"
+            WorkingDirectory="INSTALLFOLDER"
+            Icon="ext4Icon.exe"
+            IconIndex="0" />
+        <RemoveFolder Id="RemoveStartMenuFolder" On="uninstall" />
+        <RegistryValue
+            Root="HKCU"
+            Key="Software\ext4-win-driver"
+            Name="StartMenuShortcuts"
+            Type="integer"
+            Value="1"
+            KeyPath="yes" />
+      </Component>
+
+    </ComponentGroup>
+
+    <!-- Icon source for the shortcuts (re-uses the EXE's embedded icon, if any). -->
+    <Icon Id="ext4Icon.exe" SourceFile="$(var.ExePath)" />
+    <Property Id="ARPPRODUCTICON" Value="ext4Icon.exe" />
+    <Property Id="ARPURLINFOABOUT" Value="https://github.com/christhomas/ext4-win-driver" />
+    <Property Id="ARPHELPLINK" Value="https://winfsp.dev/" />
+
+  </Package>
+</Wix>

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,0 +1,78 @@
+# ext4-win-driver MSI installer
+
+WiX 4 source for the ext4-win-driver Windows installer. Produces a single
+`.msi` that installs `ext4.exe`, the `Mount-Ext4.ps1` helper, an Explorer
+right-click "Mount as ext4" verb on `.img` files, and Start Menu shortcuts.
+
+## Prerequisites
+
+1. **Rust** + the `mount` feature build chain (see top-level `README.md`).
+2. **WiX 4+ toolset.** Install with one of:
+   ```powershell
+   # .NET global tool (recommended — current as of 2026):
+   dotnet tool install --global wix
+   wix extension add WixToolset.Util.wixext
+
+   # Or via winget:
+   winget install WiXToolset.WiX
+   ```
+3. **WinFsp 2.x** on the *target* machine where the MSI will be installed.
+   The MSI does not bundle WinFsp; the installer aborts with a friendly
+   message if WinFsp is missing. Get it from <https://winfsp.dev/>.
+
+## Build
+
+From the repo root:
+
+```powershell
+# 1. Build the binary with WinFsp support.
+cargo build --release --features mount
+
+# 2. Build the MSI.
+installer\build.ps1 -ExePath target\release\ext4.exe
+```
+
+Output: `dist\ext4-win-driver-<version>.msi` (version pulled from
+`Cargo.toml` unless `-Version` is passed).
+
+`build.ps1` parameters:
+
+| Param      | Default                                       |
+|------------|-----------------------------------------------|
+| `-ExePath` | *(required)* — path to the release `ext4.exe` |
+| `-Version` | parsed from `Cargo.toml`                      |
+| `-Output`  | `dist\ext4-win-driver-<version>.msi`          |
+
+## What the MSI does
+
+- Installs `ext4.exe`, `Mount-Ext4.ps1`, and `LICENSE.txt` into
+  `%ProgramFiles%\ext4-win-driver\`.
+- Appends the install dir to the **system** `PATH`.
+- Detects WinFsp via `HKLM\SOFTWARE\WOW6432Node\WinFsp\InstallDir` (32-bit
+  view) and `HKLM\SOFTWARE\WinFsp\InstallDir` (64-bit view). Aborts with a
+  pointer to <https://winfsp.dev/> if neither is present.
+- Adds Explorer right-click "Mount as ext4" on `.img` files (via
+  `HKCR\SystemFileAssociations\.img\shell\MountAsExt4` — non-destructive;
+  the built-in Disk Management "Mount" verb keeps working for VHD/ISO).
+- Adds two Start Menu shortcuts under "ext4-win-driver":
+  - **Mount ext4 image...** — file picker → `ext4 mount`.
+  - **ext4 watch service** — runs `ext4 watch` in a console.
+- Cleans up everything on uninstall (MSI infrastructure handles it).
+
+## Uninstall
+
+Standard "Apps & features" / Add-Remove-Programs entry, or:
+
+```powershell
+msiexec /x dist\ext4-win-driver-<version>.msi
+```
+
+## Notes
+
+- The `UpgradeCode` GUID in `Product.wxs` is **stable** across versions —
+  do not regenerate it, or major-upgrade detection breaks.
+- The installer is `perMachine` and 64-bit-only (`-arch x64`). ARM64
+  support requires re-building with `-arch arm64` and a matching
+  `ext4.exe` build.
+- `Mount-Ext4.ps1` is also usable stand-alone if you don't want to install
+  the MSI — copy it next to a dev `ext4.exe` and run it.

--- a/installer/build.ps1
+++ b/installer/build.ps1
@@ -1,0 +1,142 @@
+<#
+.SYNOPSIS
+  Build the ext4-win-driver MSI installer.
+
+.DESCRIPTION
+  Wraps `wix build` (WiX 4+). Reads the version from Cargo.toml unless
+  -Version is passed. Copies the supplied ext4.exe and the project LICENSE
+  into the installer/ working area so the WiX source's relative paths
+  resolve, then emits an MSI under -Output (default
+  dist/ext4-win-driver-<version>.msi).
+
+  Prerequisites:
+    - WiX 4+ — `dotnet tool install --global wix` (or winget WiXToolset.WiX).
+    - WiX UI / Util extensions — `wix extension add WixToolset.UI.wixext`
+      and `wix extension add WixToolset.Util.wixext`.
+
+.PARAMETER ExePath
+  Path to the release ext4.exe. Required.
+
+.PARAMETER Version
+  Override the version. Default: read from ../Cargo.toml.
+
+.PARAMETER Output
+  MSI output path. Default: dist/ext4-win-driver-<version>.msi.
+
+.EXAMPLE
+  installer\build.ps1 -ExePath target\release\ext4.exe
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ExePath,
+
+    [Parameter()]
+    [string]$Version,
+
+    [Parameter()]
+    [string]$Output
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ----------------------------------------------------------------------------
+# Resolve paths. Script can be invoked from anywhere — anchor to its dir.
+# ----------------------------------------------------------------------------
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot  = Split-Path -Parent $scriptDir
+$cargoToml = Join-Path $repoRoot 'Cargo.toml'
+
+if (-not (Test-Path $ExePath)) {
+    throw "ExePath not found: $ExePath"
+}
+$ExePath = (Resolve-Path $ExePath).Path
+
+# ----------------------------------------------------------------------------
+# Pull version out of Cargo.toml (`version = "x.y.z"` in [package]) unless
+# the caller supplied one explicitly.
+# ----------------------------------------------------------------------------
+if (-not $Version) {
+    if (-not (Test-Path $cargoToml)) {
+        throw "Cargo.toml not found at $cargoToml — pass -Version explicitly."
+    }
+    $inPackage = $false
+    foreach ($line in Get-Content $cargoToml) {
+        if ($line -match '^\s*\[package\]\s*$') { $inPackage = $true; continue }
+        if ($line -match '^\s*\[') { $inPackage = $false; continue }
+        if ($inPackage -and $line -match '^\s*version\s*=\s*"([^"]+)"') {
+            $Version = $Matches[1]
+            break
+        }
+    }
+    if (-not $Version) {
+        throw "Could not read version from $cargoToml — pass -Version explicitly."
+    }
+}
+
+# ----------------------------------------------------------------------------
+# Default output path.
+# ----------------------------------------------------------------------------
+if (-not $Output) {
+    $Output = Join-Path $repoRoot "dist\ext4-win-driver-$Version.msi"
+}
+$outDir = Split-Path -Parent $Output
+if (-not (Test-Path $outDir)) {
+    New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+}
+
+# ----------------------------------------------------------------------------
+# Stage LICENSE next to Product.wxs (the WiX source references it by relative
+# path). If the repo doesn't have a LICENSE yet, write a placeholder so the
+# build doesn't fail outright — the MSI will ship whatever's there.
+# ----------------------------------------------------------------------------
+$licenseSrc = Join-Path $repoRoot 'LICENSE'
+$licenseDst = Join-Path $scriptDir 'LICENSE'
+if (Test-Path $licenseSrc) {
+    Copy-Item -Force $licenseSrc $licenseDst
+} elseif (-not (Test-Path $licenseDst)) {
+    Set-Content -Path $licenseDst -Value 'GPL-3.0 — see https://www.gnu.org/licenses/gpl-3.0.html'
+}
+
+# ----------------------------------------------------------------------------
+# Locate `wix`. Prefer the dotnet global tool; fall back to PATH.
+# ----------------------------------------------------------------------------
+$wix = Get-Command wix -ErrorAction SilentlyContinue
+if (-not $wix) {
+    throw @"
+WiX 4+ not found. Install with:
+  dotnet tool install --global wix
+  wix extension add WixToolset.UI.wixext
+  wix extension add WixToolset.Util.wixext
+or via winget: winget install WiXToolset.WiX
+"@
+}
+
+Write-Host "WiX:      $($wix.Source)"
+Write-Host "Version:  $Version"
+Write-Host "ExePath:  $ExePath"
+Write-Host "Output:   $Output"
+
+# ----------------------------------------------------------------------------
+# Invoke `wix build`. -d sets WiX preprocessor variables consumed by
+# Product.wxs as $(var.Name).
+# ----------------------------------------------------------------------------
+Push-Location $scriptDir
+try {
+    & wix build `
+        -ext WixToolset.Util.wixext `
+        -d "Version=$Version" `
+        -d "ExePath=$ExePath" `
+        -arch x64 `
+        -out $Output `
+        Product.wxs
+    if ($LASTEXITCODE -ne 0) {
+        throw "wix build failed with exit code $LASTEXITCODE"
+    }
+} finally {
+    Pop-Location
+}
+
+Write-Host ""
+Write-Host "Built: $Output"

--- a/src/device.rs
+++ b/src/device.rs
@@ -21,9 +21,28 @@ use std::path::Path;
 
 /// Random-access read source. `Send + Sync` so it can sit behind an `Arc`
 /// shared between the CLI and the C ABI's read callback.
+///
+/// `write_at` and `flush` are optional. The default impls return an error
+/// so existing read-only impls don't need to change. Implementors that
+/// open the underlying handle for write should override them.
 pub trait BlockSource: Send + Sync {
     fn read_at(&self, offset: u64, buf: &mut [u8]) -> std::io::Result<()>;
     fn size(&self) -> u64;
+
+    /// Write `buf` at `offset`. Default = NotConnected so a RW callback
+    /// fed a read-only `BlockSource` fails fast instead of corrupting.
+    fn write_at(&self, _offset: u64, _buf: &[u8]) -> std::io::Result<()> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "write_at: BlockSource is read-only",
+        ))
+    }
+
+    /// Flush buffered writes to the underlying device. Default = no-op
+    /// success (RO sources have nothing to flush).
+    fn flush(&self) -> std::io::Result<()> {
+        Ok(())
+    }
 }
 
 /// File-backed source. Works for regular files everywhere and for raw
@@ -31,13 +50,33 @@ pub trait BlockSource: Send + Sync {
 pub struct FileSource {
     file: File,
     size: u64,
+    writable: bool,
 }
 
 impl FileSource {
+    /// Open read-only.
     pub fn open(path: &Path) -> Result<Self> {
-        let file = open_with_share(path)?;
+        let file = open_with_share(path, false)?;
         let size = compute_size(&file).with_context(|| format!("sizing {path:?}"))?;
-        Ok(Self { file, size })
+        Ok(Self {
+            file,
+            size,
+            writable: false,
+        })
+    }
+
+    /// Open read-write. On Windows uses the same generous share mode
+    /// (`FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE`) plus
+    /// `.write(true)` so a mounted volume can still be reopened. On Unix
+    /// this is just `OpenOptions::new().read(true).write(true)`.
+    pub fn open_rw(path: &Path) -> Result<Self> {
+        let file = open_with_share(path, true)?;
+        let size = compute_size(&file).with_context(|| format!("sizing {path:?}"))?;
+        Ok(Self {
+            file,
+            size,
+            writable: true,
+        })
     }
 }
 
@@ -70,6 +109,48 @@ impl BlockSource for FileSource {
         }
         Ok(())
     }
+
+    #[cfg(unix)]
+    fn write_at(&self, offset: u64, buf: &[u8]) -> std::io::Result<()> {
+        use std::os::unix::fs::FileExt;
+        if !self.writable {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "FileSource opened read-only",
+            ));
+        }
+        self.file.write_all_at(buf, offset)
+    }
+
+    #[cfg(windows)]
+    fn write_at(&self, offset: u64, buf: &[u8]) -> std::io::Result<()> {
+        use std::os::windows::fs::FileExt;
+        if !self.writable {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "FileSource opened read-only",
+            ));
+        }
+        let mut total = 0usize;
+        while total < buf.len() {
+            let n = self.file.seek_write(&buf[total..], offset + total as u64)?;
+            if n == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::WriteZero,
+                    "short write",
+                ));
+            }
+            total += n;
+        }
+        Ok(())
+    }
+
+    fn flush(&self) -> std::io::Result<()> {
+        if !self.writable {
+            return Ok(());
+        }
+        self.file.sync_data()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -77,19 +158,25 @@ impl BlockSource for FileSource {
 // ---------------------------------------------------------------------------
 
 #[cfg(unix)]
-fn open_with_share(path: &Path) -> Result<File> {
-    File::open(path).with_context(|| format!("opening {path:?}"))
+fn open_with_share(path: &Path, write: bool) -> Result<File> {
+    use std::fs::OpenOptions;
+    OpenOptions::new()
+        .read(true)
+        .write(write)
+        .open(path)
+        .with_context(|| format!("opening {path:?}"))
 }
 
 #[cfg(windows)]
-fn open_with_share(path: &Path) -> Result<File> {
+fn open_with_share(path: &Path, write: bool) -> Result<File> {
     use std::fs::OpenOptions;
     use std::os::windows::fs::OpenOptionsExt;
     // FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE = 7. Required
-    // when reading a mounted volume so the kernel doesn't reject us with
-    // ERROR_SHARING_VIOLATION.
+    // when reading/writing a mounted volume so the kernel doesn't reject
+    // us with ERROR_SHARING_VIOLATION.
     OpenOptions::new()
         .read(true)
+        .write(write)
         .share_mode(0x7)
         .open(path)
         .with_context(|| format!("opening {path:?}"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod cmd;
 mod device;
 mod mount;
 mod partition;
+mod watch;
 
 #[derive(Parser)]
 #[command(name = "ext4", about = "Browse and (eventually) mount ext4 volumes on Windows")]
@@ -75,6 +76,10 @@ enum Cmd {
         #[arg(long)]
         drive: String,
     },
+    /// Watch for ext4 volumes plugging in (SD cards, USB drives) and
+    /// auto-mount them by spawning `ext4 mount` as a child process.
+    /// Windows-only; on other targets prints a hint and exits.
+    Watch,
 }
 
 fn main() -> Result<()> {
@@ -91,5 +96,6 @@ fn main() -> Result<()> {
             let m = mount::Mount::open(&mt)?;
             mount::run(m, &drive)
         }
+        Cmd::Watch => watch::run(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,8 +66,9 @@ enum Cmd {
     },
     /// Inspect partition table (MBR/GPT) of a disk image or raw device.
     Parts { image: PathBuf },
-    /// Mount the filesystem on a Windows drive letter via WinFsp (RO).
-    /// Requires the `mount` feature and a Windows host.
+    /// Mount the filesystem on a Windows drive letter via WinFsp.
+    /// Defaults to read-only; pass `--rw` for read-write. Requires the
+    /// `mount` feature and a Windows host.
     #[cfg(all(windows, feature = "mount"))]
     Mount {
         #[command(flatten)]
@@ -75,6 +76,9 @@ enum Cmd {
         /// Drive letter (`X:`) or empty directory to mount on.
         #[arg(long)]
         drive: String,
+        /// Mount read-write (default = read-only).
+        #[arg(long)]
+        rw: bool,
     },
     /// Watch for ext4 volumes plugging in (SD cards, USB drives) and
     /// auto-mount them by spawning `ext4 mount` as a child process.
@@ -92,8 +96,12 @@ fn main() -> Result<()> {
         Cmd::Tree { mt, max_depth } => cmd::tree(&mt, max_depth),
         Cmd::Parts { image } => cmd::parts(&image),
         #[cfg(all(windows, feature = "mount"))]
-        Cmd::Mount { mt, drive } => {
-            let m = mount::Mount::open(&mt)?;
+        Cmd::Mount { mt, drive, rw } => {
+            let m = if rw {
+                mount::Mount::open_rw(&mt)?
+            } else {
+                mount::Mount::open(&mt)?
+            };
             mount::run(m, &drive)
         }
         Cmd::Watch => watch::run(),

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -32,8 +32,12 @@ use crate::partition;
 /// raw fs pointer; the WinFsp adapter does the same.
 pub struct Mount {
     pub(crate) fs: *mut fs_ext4_fs_t,
-    /// Set when mounted via `fs_ext4_mount_with_callbacks`. Owned here.
+    /// Set when mounted via `fs_ext4_mount_with_callbacks` /
+    /// `fs_ext4_mount_rw_with_callbacks`. Owned here.
     cb_ctx: Option<*mut SliceCtx>,
+    /// True when mounted RW. Used by the WinFsp adapter to gate write
+    /// callbacks and drop the `read_only_volume` flag.
+    pub(crate) writable: bool,
 }
 
 // `*mut fs_ext4_fs_t` is opaque to us and the underlying `Filesystem` is
@@ -47,6 +51,35 @@ impl Mount {
             None => Self::open_direct(&mt.image),
             Some(n) => Self::open_partition(&mt.image, n),
         }
+    }
+
+    /// Same dispatch as [`open`] but routes to RW variants. Currently
+    /// only `--part N` is wired for RW (the WinFsp mount path). A direct
+    /// (whole-image) RW open could be added later but isn't needed
+    /// for the WinFsp use case where partition mounts dominate.
+    pub fn open_rw(mt: &MountArgs) -> Result<Self> {
+        match mt.part {
+            None => Self::open_direct_rw(&mt.image),
+            Some(n) => Self::open_partition_rw(&mt.image, n),
+        }
+    }
+
+    /// RW analogue of [`open_direct`] — uses `fs_ext4_mount_rw` against the
+    /// device path. Available so `--rw` works without a `--part`.
+    pub fn open_direct_rw(image: &Path) -> Result<Self> {
+        let s = image
+            .to_str()
+            .ok_or_else(|| anyhow!("image path is not valid UTF-8: {image:?}"))?;
+        let c = CString::new(s).context("image path contains NUL byte")?;
+        let fs = unsafe { fs_ext4_mount_rw(c.as_ptr()) };
+        if fs.is_null() {
+            bail!("mount_rw {image:?} failed: {}", crate::cmd::last_err());
+        }
+        Ok(Self {
+            fs,
+            cb_ctx: None,
+            writable: true,
+        })
     }
 
     pub fn open_direct(image: &Path) -> Result<Self> {
@@ -76,7 +109,11 @@ impl Mount {
             };
             bail!("mount {image:?} failed: {}{hint}", crate::cmd::last_err());
         }
-        Ok(Self { fs, cb_ctx: None })
+        Ok(Self {
+            fs,
+            cb_ctx: None,
+            writable: false,
+        })
     }
 
     pub fn open_partition(image: &Path, n: usize) -> Result<Self> {
@@ -126,6 +163,61 @@ impl Mount {
         Ok(Self {
             fs,
             cb_ctx: Some(raw),
+            writable: false,
+        })
+    }
+
+    /// RW analogue of [`open_partition`]. Opens the underlying source
+    /// with write access, plumbs read+write+flush callbacks into
+    /// `fs_ext4_mount_rw_with_callbacks`, and replays a dirty journal
+    /// before returning (eager-mount semantics).
+    pub fn open_partition_rw(image: &Path, n: usize) -> Result<Self> {
+        let src: Arc<dyn BlockSource> = Arc::new(FileSource::open_rw(image)?);
+        let parts = partition::list_from_source(src.as_ref())
+            .with_context(|| format!("listing partitions in {image:?}"))?;
+        if parts.is_empty() {
+            bail!("no partitions found in {image:?}");
+        }
+        if n == 0 || n > parts.len() {
+            bail!("--part {n} out of range (1..={})", parts.len());
+        }
+        let p = &parts[n - 1];
+        let base = p.start_lba * 512;
+        let len = p.num_sectors * 512;
+        let end = base
+            .checked_add(len)
+            .ok_or_else(|| anyhow!("partition geometry overflows u64"))?;
+        if end > src.size() {
+            bail!(
+                "partition {n} extends past device end: {end} > {} bytes",
+                src.size()
+            );
+        }
+
+        let ctx = Box::new(SliceCtx { src, base, len });
+        let raw = Box::into_raw(ctx);
+
+        let cfg = fs_ext4_blockdev_cfg_t {
+            read: Some(slice_read_cb),
+            context: raw as *mut c_void,
+            size_bytes: unsafe { (*raw).len },
+            block_size: 0,
+            write: Some(slice_write_cb),
+            flush: Some(slice_flush_cb),
+        };
+        let fs = unsafe { fs_ext4_mount_rw_with_callbacks(&cfg) };
+        if fs.is_null() {
+            unsafe { drop(Box::from_raw(raw)) };
+            bail!(
+                "mount_rw partition {n} ({}) failed: {}",
+                p.kind,
+                crate::cmd::last_err()
+            );
+        }
+        Ok(Self {
+            fs,
+            cb_ctx: Some(raw),
+            writable: true,
         })
     }
 }
@@ -175,6 +267,40 @@ extern "C" fn slice_read_cb(
     0
 }
 
+extern "C" fn slice_write_cb(
+    ctx: *mut c_void,
+    buf: *const c_void,
+    offset: u64,
+    length: u64,
+) -> c_int {
+    if ctx.is_null() || buf.is_null() {
+        return -1;
+    }
+    let ctx = unsafe { &*(ctx as *const SliceCtx) };
+    let Some(end) = offset.checked_add(length) else {
+        return -1;
+    };
+    if end > ctx.len {
+        return -1;
+    }
+    let slice = unsafe { std::slice::from_raw_parts(buf as *const u8, length as usize) };
+    if ctx.src.write_at(ctx.base + offset, slice).is_err() {
+        return -1;
+    }
+    0
+}
+
+extern "C" fn slice_flush_cb(ctx: *mut c_void) -> c_int {
+    if ctx.is_null() {
+        return -1;
+    }
+    let ctx = unsafe { &*(ctx as *const SliceCtx) };
+    if ctx.src.flush().is_err() {
+        return -1;
+    }
+    0
+}
+
 // ---------------------------------------------------------------------------
 // WinFsp adapter (feature = "mount", windows only)
 // ---------------------------------------------------------------------------
@@ -183,9 +309,13 @@ extern "C" fn slice_read_cb(
 mod winfsp_adapter {
     //! Glue between WinFsp's `FileSystemContext` and the `fs_ext4_*` C ABI.
     //!
-    //! Phase A — read-only browsing. Just enough to see ext4 contents
-    //! through Explorer; writes return STATUS_INVALID_DEVICE_REQUEST via
-    //! the trait's default impls.
+    //! RO mode (default): only read-side methods are wired; writes return
+    //! `STATUS_MEDIA_WRITE_PROTECTED` via the volume's `read_only_volume`
+    //! flag.
+    //!
+    //! RW mode (`--rw`): `create`/`write`/`set_file_size`/`set_basic_info`/
+    //! `rename`/`set_delete`/`cleanup`/`overwrite` are wired through to the
+    //! `fs_ext4_*` C ABI's mutating entry points.
     //!
     //! Path conversions: WinFsp gives backslash-separated UTF-16 paths
     //! (`\foo\bar`); the ext4 C ABI wants slash-separated UTF-8
@@ -194,6 +324,17 @@ mod winfsp_adapter {
     //! Time conversions: ext4 stores 32-bit unix epoch seconds; Windows
     //! FILETIME is 100-ns intervals since 1601-01-01. The constant offset
     //! is 11644473600 seconds.
+    //!
+    //! ## v1 write compromise
+    //!
+    //! `fs_ext4_write_file` in the C ABI is a *whole-file replace*, not a
+    //! positional write. WinFsp issues partial offset writes from the OS
+    //! cache manager. To bridge the gap, [`Ext4Context::write`] currently
+    //! reads the entire existing file, splices the new bytes in at the
+    //! requested offset, and calls `fs_ext4_write_file` with the merged
+    //! buffer. This is correct but O(filesize) per write — fine for small
+    //! files, painful for large ones. A positional `pwrite` C ABI is the
+    //! follow-up; until it lands, large-file workloads will be slow.
 
     use anyhow::{Context, Result, anyhow};
     use fs_ext4::capi::*;
@@ -202,21 +343,36 @@ mod winfsp_adapter {
     use widestring::U16CStr;
     use winfsp::Result as FspResult;
     use winfsp::filesystem::{
-        DirInfo, DirMarker, FileInfo, FileSecurity, FileSystemContext, OpenFileInfo, VolumeInfo,
-        WideNameInfo,
+        DirInfo, DirMarker, FileInfo, FileSecurity, FileSystemContext, ModificationDescriptor,
+        OpenFileInfo, VolumeInfo, WideNameInfo,
     };
     use winfsp::host::{FileSystemHost, VolumeParams};
     use windows::Win32::Foundation::{
-        STATUS_END_OF_FILE, STATUS_INVALID_DEVICE_REQUEST, STATUS_NOT_A_DIRECTORY,
-        STATUS_OBJECT_NAME_NOT_FOUND,
+        STATUS_ACCESS_DENIED, STATUS_DIRECTORY_NOT_EMPTY, STATUS_DISK_FULL, STATUS_END_OF_FILE,
+        STATUS_FILE_IS_A_DIRECTORY, STATUS_INVALID_DEVICE_REQUEST, STATUS_MEDIA_WRITE_PROTECTED,
+        STATUS_NOT_A_DIRECTORY, STATUS_OBJECT_NAME_COLLISION, STATUS_OBJECT_NAME_NOT_FOUND,
     };
     use windows::Win32::Storage::FileSystem::{
         FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_READONLY,
     };
-    use winfsp_sys::FILE_ACCESS_RIGHTS;
+    use winfsp_sys::{FILE_ACCESS_RIGHTS, FILE_FLAGS_AND_ATTRIBUTES};
 
     use crate::cmd::last_err;
     use crate::mount::Mount;
+
+    // NT CreateOptions flag — `windows::Wdk::Storage::FileSystem::FILE_DIRECTORY_FILE`
+    // would require pulling in the `Wdk_Storage_FileSystem` feature. The
+    // bit definition is fixed by NT (ntifs.h) so a literal is safer than
+    // adding another feature surface.
+    const FILE_DIRECTORY_FILE: u32 = 0x0000_0001;
+
+    /// Cleanup `Flags` bit indicating the file should be deleted now.
+    const FSP_CLEANUP_DELETE: u32 = 0x01;
+
+    /// "Leave unchanged" sentinel for `fs_ext4_chown` and `fs_ext4_utimens`
+    /// fields — matches Linux's `(uid_t)-1` / `UTIME_OMIT`-equivalent on
+    /// the C ABI side.
+    const KEEP_UNCHANGED: u32 = u32::MAX;
 
     /// Seconds between Windows FILETIME epoch (1601-01-01) and Unix epoch (1970-01-01).
     const FILETIME_EPOCH_OFFSET_SEC: u64 = 11_644_473_600;
@@ -282,8 +438,14 @@ mod winfsp_adapter {
     fn errno_to_status(errno: i32) -> windows::Win32::Foundation::NTSTATUS {
         // Coarse mapping. Refine when we hit specific cases in testing.
         match errno {
-            2 /* ENOENT */ => STATUS_OBJECT_NAME_NOT_FOUND,
-            20 /* ENOTDIR */ => STATUS_NOT_A_DIRECTORY,
+            2  /* ENOENT */    => STATUS_OBJECT_NAME_NOT_FOUND,
+            13 /* EACCES */    => STATUS_ACCESS_DENIED,
+            17 /* EEXIST */    => STATUS_OBJECT_NAME_COLLISION,
+            20 /* ENOTDIR */   => STATUS_NOT_A_DIRECTORY,
+            21 /* EISDIR */    => STATUS_FILE_IS_A_DIRECTORY,
+            28 /* ENOSPC */    => STATUS_DISK_FULL,
+            30 /* EROFS */     => STATUS_MEDIA_WRITE_PROTECTED,
+            39 /* ENOTEMPTY */ => STATUS_DIRECTORY_NOT_EMPTY,
             _ => STATUS_INVALID_DEVICE_REQUEST,
         }
     }
@@ -291,11 +453,27 @@ mod winfsp_adapter {
     /// Per-open file handle state.
     pub struct Ext4FileContext {
         pub inode: u32,
-        pub unix_path: String,
+        /// Path at open time. WinFsp gives a `file_name` to `cleanup` for
+        /// the deletion case so we don't strictly need this for delete,
+        /// but it's how `read`, `write`, etc. address the file in the C
+        /// ABI (which is path-keyed, not handle-keyed).
+        pub unix_path: Mutex<String>,
         pub is_dir: bool,
-        pub size: u64,
+        /// Cached size — used as a cheap fast path for reads beyond EOF.
+        /// Refreshed by `get_file_info`. Stale-tolerant.
+        pub size: Mutex<u64>,
         /// Cached when the open call comes in; refreshed on get_file_info.
         attr: Mutex<fs_ext4_attr_t>,
+        /// Set by `set_delete`, consumed by `cleanup`. WinFsp guarantees
+        /// `cleanup` runs after the last handle is closed, so this is the
+        /// place where the actual `unlink`/`rmdir` happens.
+        delete: Mutex<bool>,
+    }
+
+    impl Ext4FileContext {
+        fn unix_path(&self) -> String {
+            self.unix_path.lock().unwrap().clone()
+        }
     }
 
     /// Filesystem-wide context shared across all WinFsp callbacks.
@@ -377,10 +555,11 @@ mod winfsp_adapter {
             populate_file_info(&attr, file_info.as_mut());
             Ok(Ext4FileContext {
                 inode: attr.inode,
-                unix_path,
+                unix_path: Mutex::new(unix_path),
                 is_dir: matches!(attr.file_type, fs_ext4_file_type_t::Dir),
-                size: attr.size,
+                size: Mutex::new(attr.size),
                 attr: Mutex::new(attr),
+                delete: Mutex::new(false),
             })
         }
 
@@ -393,8 +572,10 @@ mod winfsp_adapter {
             context: &Self::FileContext,
             file_info: &mut FileInfo,
         ) -> FspResult<()> {
-            let attr = stat_path(self.mount.fs, &context.unix_path)?;
+            let path = context.unix_path();
+            let attr = stat_path(self.mount.fs, &path)?;
             populate_file_info(&attr, file_info);
+            *context.size.lock().unwrap() = attr.size;
             *context.attr.lock().unwrap() = attr;
             Ok(())
         }
@@ -408,10 +589,12 @@ mod winfsp_adapter {
             if context.is_dir {
                 return Err(STATUS_INVALID_DEVICE_REQUEST.into());
             }
-            if offset >= context.size {
+            let cur_size = *context.size.lock().unwrap();
+            if offset >= cur_size {
                 return Err(STATUS_END_OF_FILE.into());
             }
-            let cp = CString::new(context.unix_path.as_str())
+            let path = context.unix_path();
+            let cp = CString::new(path)
                 .map_err(|_| windows::core::Error::from(STATUS_OBJECT_NAME_NOT_FOUND))?;
             let n = unsafe {
                 fs_ext4_read_file(
@@ -439,7 +622,8 @@ mod winfsp_adapter {
             if !context.is_dir {
                 return Err(STATUS_NOT_A_DIRECTORY.into());
             }
-            let cp = CString::new(context.unix_path.as_str())
+            let parent_path = context.unix_path();
+            let cp = CString::new(parent_path.clone())
                 .map_err(|_| windows::core::Error::from(STATUS_OBJECT_NAME_NOT_FOUND))?;
             let iter = unsafe { fs_ext4_dir_open(self.mount.fs, cp.as_ptr()) };
             if iter.is_null() {
@@ -481,10 +665,10 @@ mod winfsp_adapter {
                     continue;
                 }
 
-                let child_path = if context.unix_path == "/" {
+                let child_path = if parent_path == "/" {
                     format!("/{name}")
                 } else {
-                    format!("{}/{name}", context.unix_path)
+                    format!("{}/{name}", parent_path)
                 };
                 let attr = match stat_path(self.mount.fs, &child_path) {
                     Ok(a) => a,
@@ -516,6 +700,369 @@ mod winfsp_adapter {
             out_volume_info.set_volume_label(label);
             Ok(())
         }
+
+        // -----------------------------------------------------------------
+        // RW-side methods. These are wired unconditionally; on a RO mount
+        // the volume's `read_only_volume` flag means WinFsp short-circuits
+        // them with STATUS_MEDIA_WRITE_PROTECTED before dispatch, so the
+        // bodies don't need a `if !self.mount.writable { ... }` guard.
+        // -----------------------------------------------------------------
+
+        fn create(
+            &self,
+            file_name: &U16CStr,
+            create_options: u32,
+            _granted_access: FILE_ACCESS_RIGHTS,
+            file_attributes: FILE_FLAGS_AND_ATTRIBUTES,
+            _security_descriptor: Option<&[c_void]>,
+            _allocation_size: u64,
+            _extra_buffer: Option<&[u8]>,
+            _extra_buffer_is_reparse_point: bool,
+            file_info: &mut OpenFileInfo,
+        ) -> FspResult<Self::FileContext> {
+            let unix_path =
+                winpath_to_unix(file_name).map_err(|_| STATUS_OBJECT_NAME_NOT_FOUND)?;
+            let cp = CString::new(unix_path.as_str())
+                .map_err(|_| windows::core::Error::from(STATUS_OBJECT_NAME_NOT_FOUND))?;
+
+            // POSIX permission bits — Windows doesn't supply mode_t, so
+            // we mint sensible defaults: 0o755 for dirs, 0o644 for files.
+            // READONLY attribute → strip the write bits so Explorer's
+            // "read-only" property round-trips.
+            let is_dir = create_options & FILE_DIRECTORY_FILE != 0;
+            let mut mode: u16 = if is_dir { 0o755 } else { 0o644 };
+            if file_attributes & FILE_ATTRIBUTE_READONLY.0 != 0 {
+                mode &= !0o222;
+            }
+
+            let ino = if is_dir {
+                unsafe { fs_ext4_mkdir(self.mount.fs, cp.as_ptr(), mode) }
+            } else {
+                unsafe { fs_ext4_create(self.mount.fs, cp.as_ptr(), mode) }
+            };
+            if ino == 0 {
+                let errno = unsafe { fs_ext4_last_errno() };
+                return Err(errno_to_status(errno).into());
+            }
+
+            let attr = stat_path(self.mount.fs, &unix_path)?;
+            populate_file_info(&attr, file_info.as_mut());
+            Ok(Ext4FileContext {
+                inode: attr.inode,
+                unix_path: Mutex::new(unix_path),
+                is_dir,
+                size: Mutex::new(attr.size),
+                attr: Mutex::new(attr),
+                delete: Mutex::new(false),
+            })
+        }
+
+        fn write(
+            &self,
+            context: &Self::FileContext,
+            buffer: &[u8],
+            offset: u64,
+            write_to_eof: bool,
+            constrained_io: bool,
+            file_info: &mut FileInfo,
+        ) -> FspResult<u32> {
+            if context.is_dir {
+                return Err(STATUS_FILE_IS_A_DIRECTORY.into());
+            }
+            let path = context.unix_path();
+            let cp = CString::new(path.as_str())
+                .map_err(|_| windows::core::Error::from(STATUS_OBJECT_NAME_NOT_FOUND))?;
+
+            // Re-stat so we have an authoritative current size; the
+            // `context.size` cache can lag if the file was mutated via
+            // another handle on the same volume.
+            let attr = stat_path(self.mount.fs, &path)?;
+            let cur_size = attr.size;
+
+            // Resolve effective offset + accepted byte count.
+            let eff_offset = if write_to_eof { cur_size } else { offset };
+            let mut accept_len = buffer.len() as u64;
+            if constrained_io {
+                if eff_offset >= cur_size {
+                    // No bytes accepted — write past EOF on a constrained
+                    // request is a no-op success per the WinFsp contract.
+                    populate_file_info(&attr, file_info);
+                    return Ok(0);
+                }
+                let avail = cur_size - eff_offset;
+                if accept_len > avail {
+                    accept_len = avail;
+                }
+            }
+            if accept_len == 0 {
+                populate_file_info(&attr, file_info);
+                return Ok(0);
+            }
+            let new_end = eff_offset
+                .checked_add(accept_len)
+                .ok_or_else(|| windows::core::Error::from(STATUS_INVALID_DEVICE_REQUEST))?;
+            let new_size = new_end.max(cur_size);
+
+            // v1 compromise: the C ABI's `fs_ext4_write_file` is a
+            // whole-file replace, so we read existing content, splice the
+            // new bytes in, and write the merged buffer back.
+            let mut merged: Vec<u8> = vec![0u8; new_size as usize];
+            if cur_size > 0 {
+                let n = unsafe {
+                    fs_ext4_read_file(
+                        self.mount.fs,
+                        cp.as_ptr(),
+                        merged.as_mut_ptr() as *mut c_void,
+                        0,
+                        cur_size,
+                    )
+                };
+                if n < 0 {
+                    let errno = unsafe { fs_ext4_last_errno() };
+                    return Err(errno_to_status(errno).into());
+                }
+            }
+            // Splice the new bytes in. `merged` is already `new_size`
+            // bytes; bytes between `cur_size` and `eff_offset` (a hole
+            // created by writing past EOF) stay zero.
+            let dst = &mut merged[eff_offset as usize..(eff_offset + accept_len) as usize];
+            dst.copy_from_slice(&buffer[..accept_len as usize]);
+
+            let rc = unsafe {
+                fs_ext4_write_file(
+                    self.mount.fs,
+                    cp.as_ptr(),
+                    merged.as_ptr() as *const c_void,
+                    merged.len() as u64,
+                )
+            };
+            if rc < 0 {
+                let errno = unsafe { fs_ext4_last_errno() };
+                return Err(errno_to_status(errno).into());
+            }
+
+            // Refresh size + attrs for the caller.
+            let attr2 = stat_path(self.mount.fs, &path)?;
+            populate_file_info(&attr2, file_info);
+            *context.size.lock().unwrap() = attr2.size;
+            *context.attr.lock().unwrap() = attr2;
+            Ok(accept_len as u32)
+        }
+
+        fn set_file_size(
+            &self,
+            context: &Self::FileContext,
+            new_size: u64,
+            _set_allocation_size: bool,
+            file_info: &mut FileInfo,
+        ) -> FspResult<()> {
+            if context.is_dir {
+                return Err(STATUS_FILE_IS_A_DIRECTORY.into());
+            }
+            let path = context.unix_path();
+            let cp = CString::new(path.as_str())
+                .map_err(|_| windows::core::Error::from(STATUS_OBJECT_NAME_NOT_FOUND))?;
+            let rc = unsafe { fs_ext4_truncate(self.mount.fs, cp.as_ptr(), new_size) };
+            if rc != 0 {
+                let errno = unsafe { fs_ext4_last_errno() };
+                return Err(errno_to_status(errno).into());
+            }
+            let attr = stat_path(self.mount.fs, &path)?;
+            populate_file_info(&attr, file_info);
+            *context.size.lock().unwrap() = attr.size;
+            *context.attr.lock().unwrap() = attr;
+            Ok(())
+        }
+
+        fn overwrite(
+            &self,
+            context: &Self::FileContext,
+            _file_attributes: FILE_FLAGS_AND_ATTRIBUTES,
+            _replace_file_attributes: bool,
+            _allocation_size: u64,
+            _extra_buffer: Option<&[u8]>,
+            file_info: &mut FileInfo,
+        ) -> FspResult<()> {
+            // WinFsp Overwrite = "the file's content is being replaced".
+            // We truncate to 0 here; the cache manager will follow up with
+            // Write calls for the new bytes.
+            if context.is_dir {
+                return Err(STATUS_FILE_IS_A_DIRECTORY.into());
+            }
+            let path = context.unix_path();
+            let cp = CString::new(path.as_str())
+                .map_err(|_| windows::core::Error::from(STATUS_OBJECT_NAME_NOT_FOUND))?;
+            let rc = unsafe { fs_ext4_truncate(self.mount.fs, cp.as_ptr(), 0) };
+            if rc != 0 {
+                let errno = unsafe { fs_ext4_last_errno() };
+                return Err(errno_to_status(errno).into());
+            }
+            let attr = stat_path(self.mount.fs, &path)?;
+            populate_file_info(&attr, file_info);
+            *context.size.lock().unwrap() = attr.size;
+            *context.attr.lock().unwrap() = attr;
+            Ok(())
+        }
+
+        fn set_basic_info(
+            &self,
+            context: &Self::FileContext,
+            _file_attributes: u32,
+            _creation_time: u64,
+            last_access_time: u64,
+            last_write_time: u64,
+            _last_change_time: u64,
+            file_info: &mut FileInfo,
+        ) -> FspResult<()> {
+            // 0 means "leave unchanged" per WinFsp; we map that to
+            // KEEP_UNCHANGED for the C ABI. ext4 stores second-precision
+            // timestamps in the standard fields, so we drop the sub-second
+            // residue (the C ABI accepts nsec but the underlying inode
+            // only persists it when i_extra_isize covers it; for v1 we
+            // pass 0).
+            let path = context.unix_path();
+            let cp = CString::new(path.as_str())
+                .map_err(|_| windows::core::Error::from(STATUS_OBJECT_NAME_NOT_FOUND))?;
+            let atime_sec = filetime_to_unix(last_access_time).unwrap_or(KEEP_UNCHANGED);
+            let mtime_sec = filetime_to_unix(last_write_time).unwrap_or(KEEP_UNCHANGED);
+            if atime_sec != KEEP_UNCHANGED || mtime_sec != KEEP_UNCHANGED {
+                let rc = unsafe {
+                    fs_ext4_utimens(
+                        self.mount.fs,
+                        cp.as_ptr(),
+                        atime_sec,
+                        0,
+                        mtime_sec,
+                        0,
+                    )
+                };
+                if rc != 0 {
+                    let errno = unsafe { fs_ext4_last_errno() };
+                    return Err(errno_to_status(errno).into());
+                }
+            }
+            // file_attributes (READONLY etc.) intentionally not mapped in
+            // v1 — chmod-driven posix bits are the source of truth.
+            let attr = stat_path(self.mount.fs, &path)?;
+            populate_file_info(&attr, file_info);
+            *context.attr.lock().unwrap() = attr;
+            Ok(())
+        }
+
+        fn rename(
+            &self,
+            context: &Self::FileContext,
+            file_name: &U16CStr,
+            new_file_name: &U16CStr,
+            _replace_if_exists: bool,
+        ) -> FspResult<()> {
+            // The C ABI rejects existing destinations regardless of
+            // `replace_if_exists` (overwrite-on-rename is a follow-up in
+            // the library). We thread the flag through anyway so the
+            // signature stays honest.
+            let src = winpath_to_unix(file_name).map_err(|_| STATUS_OBJECT_NAME_NOT_FOUND)?;
+            let dst = winpath_to_unix(new_file_name).map_err(|_| STATUS_OBJECT_NAME_NOT_FOUND)?;
+            let csrc = CString::new(src.as_str())
+                .map_err(|_| windows::core::Error::from(STATUS_OBJECT_NAME_NOT_FOUND))?;
+            let cdst = CString::new(dst.as_str())
+                .map_err(|_| windows::core::Error::from(STATUS_OBJECT_NAME_NOT_FOUND))?;
+            let rc =
+                unsafe { fs_ext4_rename(self.mount.fs, csrc.as_ptr(), cdst.as_ptr()) };
+            if rc != 0 {
+                let errno = unsafe { fs_ext4_last_errno() };
+                return Err(errno_to_status(errno).into());
+            }
+            // Update the open handle's path so subsequent ops resolve the
+            // moved file correctly.
+            *context.unix_path.lock().unwrap() = dst;
+            Ok(())
+        }
+
+        fn set_delete(
+            &self,
+            context: &Self::FileContext,
+            _file_name: &U16CStr,
+            delete_file: bool,
+        ) -> FspResult<()> {
+            *context.delete.lock().unwrap() = delete_file;
+            Ok(())
+        }
+
+        fn cleanup(&self, context: &Self::FileContext, _file_name: Option<&U16CStr>, flags: u32) {
+            if flags & FSP_CLEANUP_DELETE == 0 {
+                return;
+            }
+            if !*context.delete.lock().unwrap() {
+                return;
+            }
+            let path = context.unix_path();
+            let Ok(cp) = CString::new(path.as_str()) else {
+                return;
+            };
+            // No way to report failure from cleanup — Windows interface
+            // limitation. Best effort.
+            let _ = if context.is_dir {
+                unsafe { fs_ext4_rmdir(self.mount.fs, cp.as_ptr()) }
+            } else {
+                unsafe { fs_ext4_unlink(self.mount.fs, cp.as_ptr()) }
+            };
+        }
+
+        fn flush(
+            &self,
+            _context: Option<&Self::FileContext>,
+            file_info: &mut FileInfo,
+        ) -> FspResult<()> {
+            // The C ABI exposes no fs-level flush hook (the journal is
+            // flushed inside each mutating call already, and the block
+            // device flush callback wired by `slice_flush_cb` runs on
+            // every commit). So this is a successful no-op. We do
+            // refresh `file_info` if a context is provided so WinFsp
+            // gets up-to-date metadata after a flush.
+            if let Some(ctx) = _context {
+                let path = ctx.unix_path();
+                if let Ok(attr) = stat_path(self.mount.fs, &path) {
+                    populate_file_info(&attr, file_info);
+                    *ctx.attr.lock().unwrap() = attr;
+                }
+            }
+            Ok(())
+        }
+
+        fn set_security(
+            &self,
+            _context: &Self::FileContext,
+            _security_information: u32,
+            _modification_descriptor: ModificationDescriptor,
+        ) -> FspResult<()> {
+            // v1: pretend success. ext4 ACL/security model maps awkwardly
+            // to NT SDs and Explorer doesn't gate writes on this path
+            // when the volume isn't read-only. Return Ok rather than
+            // INVALID_DEVICE_REQUEST so apps that always set security
+            // on create (Office, etc.) don't blow up.
+            Ok(())
+        }
+    }
+
+    /// FILETIME (100-ns since 1601) → Unix-seconds. Returns `None` for
+    /// 0 (WinFsp's "leave unchanged" sentinel) and for FILETIMEs that
+    /// predate the Unix epoch (clamped to `None` rather than wrapping).
+    fn filetime_to_unix(ft: u64) -> Option<u32> {
+        if ft == 0 {
+            return None;
+        }
+        let secs_since_1601 = ft / 10_000_000;
+        if secs_since_1601 < FILETIME_EPOCH_OFFSET_SEC {
+            return None;
+        }
+        let unix = secs_since_1601 - FILETIME_EPOCH_OFFSET_SEC;
+        if unix > u32::MAX as u64 {
+            // Beyond Y2038 (in unix32 land). We pass through the high
+            // bits anyway — the C ABI takes u32 and ext4 either truncates
+            // or stores extra precision via xattrs. For v1 just clamp.
+            return Some(u32::MAX - 1);
+        }
+        Some(unix as u32)
     }
 
     /// Mount the given ext4 source on a Windows mount point.
@@ -524,6 +1071,7 @@ mod winfsp_adapter {
     /// directory. Blocks until the user presses Ctrl-C, then unmounts.
     pub fn run(mount: Mount, mount_point: &str) -> Result<()> {
         let _init = winfsp::winfsp_init().context("WinFsp not installed?")?;
+        let writable = mount.writable;
 
         let ctx = Ext4Context::new(mount)?;
 
@@ -536,8 +1084,14 @@ mod winfsp_adapter {
             .case_sensitive_search(true)
             .case_preserved_names(true)
             .unicode_on_disk(true)
-            .read_only_volume(true)
             .filesystem_name("ext4");
+        // Default: read-only volume. Drop the flag for `--rw` mounts so
+        // WinFsp dispatches mutating ops to our `create`/`write`/etc.
+        // handlers instead of short-circuiting them with
+        // STATUS_MEDIA_WRITE_PROTECTED.
+        if !writable {
+            params.read_only_volume(true);
+        }
 
         let mut host = FileSystemHost::new(params, ctx)
             .map_err(|e| anyhow!("FileSystemHost::new failed: {e}"))?;
@@ -549,7 +1103,8 @@ mod winfsp_adapter {
         host.start()
             .map_err(|e| anyhow!("FileSystemHost::start failed: {e}"))?;
 
-        println!("ext4 mounted at {mount_point}. Ctrl-C to unmount.");
+        let mode = if writable { "RW" } else { "RO" };
+        println!("ext4 mounted at {mount_point} ({mode}). Ctrl-C to unmount.");
         // Block until Ctrl-C; WinFsp's host runs on its own threads.
         let (tx, rx) = std::sync::mpsc::channel();
         ctrlc::set_handler(move || {

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,0 +1,402 @@
+//! Auto-mount watcher for Windows volume arrival/removal.
+//!
+//! Runs as a foreground process. On Windows, listens for
+//! `WM_DEVICECHANGE` (`DBT_DEVICEARRIVAL` / `DBT_DEVICEREMOVECOMPLETE`)
+//! filtered to `DBT_DEVTYP_VOLUME`, probes each newly-arrived volume for
+//! an ext4 superblock, and on a hit spawns `ext4 mount <device> --drive
+//! <letter>` as a child process. On removal, kills the child so its
+//! WinFsp `Drop` tears the mount down cleanly.
+//!
+//! Self-contained: never links WinFsp directly. The current binary is
+//! re-exec'd with the `mount` subcommand — that subcommand is the one
+//! gated on the `mount` feature + Windows target.
+//!
+//! On non-Windows the [`run`] entrypoint just prints a hint and returns
+//! `Ok(())` so the CLI dispatcher remains uniform.
+//!
+//! Event source: `RegisterDeviceNotification` + a hidden message-only
+//! window. Picked over WMI because `windows-sys` already covers it; no
+//! new dep cost. The downside (a message pump on the calling thread) is
+//! tiny — the watcher's whole job is to sit in that pump.
+
+use anyhow::Result;
+
+#[cfg(target_os = "windows")]
+pub fn run() -> Result<()> {
+    imp::run()
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn run() -> Result<()> {
+    eprintln!("[watch] is Windows-only — this build is non-Windows, exiting.");
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+mod imp {
+    //! Windows implementation. Layout:
+    //!
+    //!   1. `State` — children map + Win32 handles, behind `Mutex`.
+    //!   2. `run` — install Ctrl-C handler, create message-only window,
+    //!      register volume notifications, pump until WM_QUIT.
+    //!   3. `wnd_proc` — handle WM_DEVICECHANGE, dispatch into State.
+    //!   4. helpers: `unitmask_to_letters`, `probe_ext4`, `pick_drive_letter`.
+
+    use anyhow::{Context, Result, anyhow};
+    use std::collections::HashMap;
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    use std::path::Path;
+    use std::process::{Child, Command};
+    use std::ptr;
+    use std::sync::{Mutex, OnceLock};
+
+    use windows_sys::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
+    use windows_sys::Win32::Storage::FileSystem::GetLogicalDrives;
+    use windows_sys::Win32::System::LibraryLoader::GetModuleHandleW;
+    use windows_sys::Win32::System::Threading::GetCurrentThreadId;
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        CreateWindowExW, DBT_DEVICEARRIVAL, DBT_DEVICEREMOVECOMPLETE, DBT_DEVTYP_VOLUME,
+        DEVICE_NOTIFY_WINDOW_HANDLE, DEV_BROADCAST_HDR, DEV_BROADCAST_VOLUME, DefWindowProcW,
+        DestroyWindow, DispatchMessageW, GWLP_USERDATA, GetMessageW, GetWindowLongPtrW,
+        HWND_MESSAGE, MSG, PostThreadMessageW, RegisterClassW, RegisterDeviceNotificationW,
+        SetWindowLongPtrW, TranslateMessage, UnregisterClassW, UnregisterDeviceNotification,
+        WM_DEVICECHANGE, WM_QUIT, WNDCLASSW,
+    };
+
+    use crate::device::{BlockSource, FileSource};
+
+    /// Window class name. Whatever — just needs to be unique to this
+    /// process. Wide-encoded inline to avoid bringing in widestring.
+    const CLASS_NAME: &[u16] = &[
+        b'e' as u16, b'x' as u16, b't' as u16, b'4' as u16, b'_' as u16, b'w' as u16,
+        b'a' as u16, b't' as u16, b'c' as u16, b'h' as u16, 0,
+    ];
+
+    /// Shared between the wndproc and the Ctrl-C handler. Single instance
+    /// per process (a second `watch` invocation in the same process would
+    /// be a programming error). `OnceLock` so we initialise lazily and
+    /// give the wndproc a stable pointer for `GWLP_USERDATA`.
+    fn state() -> &'static Mutex<State> {
+        static STATE: OnceLock<Mutex<State>> = OnceLock::new();
+        STATE.get_or_init(|| Mutex::new(State::default()))
+    }
+
+    #[derive(Default)]
+    struct State {
+        /// Drive-letter device path (`\\.\E:`) → spawned `ext4 mount` child.
+        children: HashMap<String, Child>,
+        /// Set on Ctrl-C / WM_QUIT path; the wndproc consults this so it
+        /// stops spawning new mounts during shutdown.
+        shutting_down: bool,
+    }
+
+    pub fn run() -> Result<()> {
+        // Take a stable static pointer to State — passed to the wndproc
+        // via GWLP_USERDATA so it can find us during message dispatch.
+        let state_ptr = state() as *const Mutex<State> as isize;
+
+        // Install Ctrl-C handler. Posts WM_QUIT to wake the message
+        // pump, which then unwinds via the cleanup at end of `run`.
+        let main_thread = unsafe { GetCurrentThreadId() };
+        ctrlc::set_handler(move || {
+            // Mark shutdown so any in-flight WM_DEVICECHANGE doesn't
+            // race a new spawn against our cleanup.
+            if let Ok(mut s) = state().lock() {
+                s.shutting_down = true;
+            }
+            unsafe {
+                PostThreadMessageW(main_thread, WM_QUIT, 0, 0);
+            }
+        })
+        .context("installing Ctrl-C handler")?;
+
+        unsafe { run_pump(state_ptr) }
+    }
+
+    /// Build the message-only window, register for volume events, drain
+    /// the message pump until WM_QUIT, then tear everything down.
+    unsafe fn run_pump(state_ptr: isize) -> Result<()> {
+        let hinstance = GetModuleHandleW(ptr::null());
+
+        // Register window class (idempotent failure is fine — a previous
+        // `watch` run in the same process may have registered already).
+        let mut wc: WNDCLASSW = std::mem::zeroed();
+        wc.lpfnWndProc = Some(wnd_proc);
+        wc.hInstance = hinstance;
+        wc.lpszClassName = CLASS_NAME.as_ptr();
+        let atom = RegisterClassW(&wc);
+        if atom == 0 {
+            // Re-using an existing class is fine; otherwise propagate the
+            // last OS error so the user sees it.
+            let err = std::io::Error::last_os_error();
+            // ERROR_CLASS_ALREADY_EXISTS = 1410
+            if err.raw_os_error() != Some(1410) {
+                return Err(anyhow!("RegisterClassW failed: {err}"));
+            }
+        }
+
+        let hwnd: HWND = CreateWindowExW(
+            0,
+            CLASS_NAME.as_ptr(),
+            ptr::null(),
+            0,
+            0,
+            0,
+            0,
+            0,
+            HWND_MESSAGE,
+            ptr::null_mut(),
+            hinstance,
+            ptr::null(),
+        );
+        if hwnd.is_null() {
+            return Err(anyhow!(
+                "CreateWindowExW(HWND_MESSAGE) failed: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+
+        // Stash state pointer so wnd_proc can find it. SetWindowLongPtrW
+        // returns the previous value (0 on first set), and to detect a
+        // genuine error we'd need to clear+check GetLastError. Skipped —
+        // we own this freshly-created window.
+        SetWindowLongPtrW(hwnd, GWLP_USERDATA, state_ptr);
+
+        // Subscribe to filesystem-volume arrival/removal events.
+        let mut filter: DEV_BROADCAST_VOLUME = std::mem::zeroed();
+        filter.dbcv_size = std::mem::size_of::<DEV_BROADCAST_VOLUME>() as u32;
+        filter.dbcv_devicetype = DBT_DEVTYP_VOLUME;
+        let dev_handle = RegisterDeviceNotificationW(
+            hwnd,
+            &filter as *const _ as *const _,
+            DEVICE_NOTIFY_WINDOW_HANDLE,
+        );
+        if dev_handle.is_null() {
+            DestroyWindow(hwnd);
+            return Err(anyhow!(
+                "RegisterDeviceNotificationW failed: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+
+        println!("[watch] listening for ext4 volume arrivals. Ctrl-C to stop.");
+
+        // Message pump. GetMessageW returns 0 on WM_QUIT (the Ctrl-C
+        // path posts that), -1 on error, anything else means dispatch.
+        let mut msg: MSG = std::mem::zeroed();
+        loop {
+            let r = GetMessageW(&mut msg, ptr::null_mut(), 0, 0);
+            if r == 0 {
+                break;
+            }
+            if r == -1 {
+                eprintln!(
+                    "[watch] GetMessageW error: {}",
+                    std::io::Error::last_os_error()
+                );
+                break;
+            }
+            TranslateMessage(&msg);
+            DispatchMessageW(&msg);
+        }
+
+        // Cleanup: unregister, kill children, destroy window.
+        UnregisterDeviceNotification(dev_handle);
+        DestroyWindow(hwnd);
+        UnregisterClassW(CLASS_NAME.as_ptr(), hinstance);
+
+        let mut st = state().lock().unwrap();
+        st.shutting_down = true;
+        let drained: Vec<(String, Child)> = st.children.drain().collect();
+        drop(st);
+        for (dev, mut child) in drained {
+            // Best-effort kill + reap; child's WinFsp Drop unmounts.
+            let _ = child.kill();
+            let _ = child.wait();
+            println!("[watch] {dev} → child unmounted (shutdown)");
+        }
+        Ok(())
+    }
+
+    /// Window procedure. Dispatches WM_DEVICECHANGE; everything else
+    /// falls through to DefWindowProcW.
+    unsafe extern "system" fn wnd_proc(
+        hwnd: HWND,
+        msg: u32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+    ) -> LRESULT {
+        if msg == WM_DEVICECHANGE {
+            let event = wparam as u32;
+            if event == DBT_DEVICEARRIVAL || event == DBT_DEVICEREMOVECOMPLETE {
+                let hdr = lparam as *const DEV_BROADCAST_HDR;
+                if !hdr.is_null() && (*hdr).dbch_devicetype == DBT_DEVTYP_VOLUME {
+                    let vol = lparam as *const DEV_BROADCAST_VOLUME;
+                    let unitmask = (*vol).dbcv_unitmask;
+                    let state_ptr =
+                        GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *const Mutex<State>;
+                    if !state_ptr.is_null() {
+                        let state: &Mutex<State> = &*state_ptr;
+                        for letter in unitmask_to_letters(unitmask) {
+                            if event == DBT_DEVICEARRIVAL {
+                                handle_arrival(state, letter);
+                            } else {
+                                handle_removal(state, letter);
+                            }
+                        }
+                    }
+                }
+            }
+            // Per docs, return TRUE to grant any pending request; for
+            // arrivals/removals the return value is ignored, so 1 is fine.
+            return 1;
+        }
+        DefWindowProcW(hwnd, msg, wparam, lparam)
+    }
+
+    /// `DBT_DEVICEARRIVAL` for a volume: probe the new drive letter,
+    /// and if it carries an ext4 superblock, spawn `ext4 mount …`.
+    fn handle_arrival(state: &Mutex<State>, letter: char) {
+        // Don't spawn during shutdown.
+        if state.lock().map(|s| s.shutting_down).unwrap_or(true) {
+            return;
+        }
+
+        let dev = format!("\\\\.\\{letter}:");
+        let dev_path = Path::new(&dev);
+
+        match probe_ext4(dev_path) {
+            Ok(true) => {}
+            Ok(false) => return,
+            Err(e) => {
+                eprintln!("[watch] probe {dev} failed: {e:#}");
+                return;
+            }
+        }
+
+        let mount_letter = match pick_drive_letter() {
+            Some(c) => c,
+            None => {
+                eprintln!("[watch] {dev} ext4 detected but no free drive letter");
+                return;
+            }
+        };
+
+        println!("[watch] ext4 detected on {dev} → mounting on {mount_letter}:");
+
+        let exe = match std::env::current_exe() {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("[watch] current_exe() failed: {e}");
+                return;
+            }
+        };
+        let drive_arg = format!("{mount_letter}:");
+        match Command::new(&exe)
+            .arg("mount")
+            .arg(&dev)
+            .arg("--drive")
+            .arg(&drive_arg)
+            .spawn()
+        {
+            Ok(child) => {
+                let mut st = match state.lock() {
+                    Ok(g) => g,
+                    Err(_) => return,
+                };
+                // Track by the *source* device path so removal lookups
+                // match what Windows reports.
+                st.children.insert(dev.clone(), child);
+                // Stash the mount letter in a tiny side-channel so the
+                // removal log can show "unmounted from F:". We piggyback
+                // on a separate map to keep the Child handling unchanged.
+                let _ = mount_letters().lock().map(|mut m| {
+                    m.insert(dev, mount_letter);
+                });
+            }
+            Err(e) => {
+                eprintln!("[watch] spawn `ext4 mount {dev} --drive {drive_arg}` failed: {e}");
+            }
+        }
+    }
+
+    /// `DBT_DEVICEREMOVECOMPLETE` for a volume: kill the matching child.
+    fn handle_removal(state: &Mutex<State>, letter: char) {
+        let dev = format!("\\\\.\\{letter}:");
+        let mut st = match state.lock() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+        if let Some(mut child) = st.children.remove(&dev) {
+            let mount_letter_str = mount_letters()
+                .lock()
+                .ok()
+                .and_then(|mut m| m.remove(&dev))
+                .map(|c| format!("{c}:"))
+                .unwrap_or_else(|| "?".into());
+            // Best-effort: WinFsp's Drop in the child should still
+            // tear the mount down once the process exits.
+            let _ = child.kill();
+            let _ = child.wait();
+            println!("[watch] {dev} removed → unmounted from {mount_letter_str}");
+        }
+    }
+
+    /// Tiny side-table keyed by source device → mount letter, just for
+    /// logging on removal. Not needed for correctness; a clean impl
+    /// would fold this into `State.children` as `(Child, char)` instead.
+    fn mount_letters() -> &'static Mutex<HashMap<String, char>> {
+        static M: OnceLock<Mutex<HashMap<String, char>>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    /// Decode `DEV_BROADCAST_VOLUME::dbcv_unitmask` (bit N = drive A+N)
+    /// into the list of affected drive letters.
+    fn unitmask_to_letters(mask: u32) -> Vec<char> {
+        let mut out = Vec::new();
+        for i in 0..26u32 {
+            if (mask >> i) & 1 != 0 {
+                out.push((b'A' + i as u8) as char);
+            }
+        }
+        out
+    }
+
+    /// Probe the device at `path` for an ext4 superblock. The superblock
+    /// starts at byte 1024; `s_magic` lives at offset 0x38 within it.
+    /// We just read those 2 bytes and check for `0xEF53` LE.
+    fn probe_ext4(path: &Path) -> Result<bool> {
+        let src = FileSource::open(path)
+            .with_context(|| format!("opening {} for ext4 probe", path.display()))?;
+        let mut magic = [0u8; 2];
+        // Best-effort: device too small or unreadable → not ext4.
+        if src.read_at(1024 + 0x38, &mut magic).is_err() {
+            return Ok(false);
+        }
+        Ok(magic == [0x53, 0xEF])
+    }
+
+    /// Pick the lowest free drive letter in `E..=Z` (skipping ones
+    /// already in use according to `GetLogicalDrives`). Returns `None`
+    /// if none are free.
+    fn pick_drive_letter() -> Option<char> {
+        let in_use = unsafe { GetLogicalDrives() };
+        // Bit 0 = A, bit 4 = E, …
+        for i in 4u32..26 {
+            if (in_use >> i) & 1 == 0 {
+                return Some((b'A' + i as u8) as char);
+            }
+        }
+        None
+    }
+
+    // OsStr → wide silencer kept for potential future use (path
+    // conversion when probing whole-disk arrivals via PhysicalDriveN).
+    // TODO(whole-disk): when DBT_DEVTYP_HANDLE / PhysicalDriveN events
+    // arrive, walk partition::list_from_source and probe each slice.
+    #[allow(dead_code)]
+    fn os_to_wide(s: &OsStr) -> Vec<u16> {
+        s.encode_wide().chain(std::iter::once(0)).collect()
+    }
+}

--- a/test-matrix.json
+++ b/test-matrix.json
@@ -1,0 +1,243 @@
+{
+  "_format": "v1",
+  "_doc": "ext4-win-driver matrix work list. See docs/test-harness.md. Each scenario name is unique. status starts at 'pending'; agents transition via scripts/claim-scenario.sh. Schema per scenario: image (file under EXT4_TEST_DISKS), mount_args (extra argv after `mount <image> --drive X:`), operations[] (typed verb list, see run-scenario.ps1), post_verify (optional 'fsck-ext4-strict' hook). Hashes captured from ext4 CLI on macOS against the canonical test images at /Volumes/sdcard256gb/projects/rust-fs-ext4/test-disks/.",
+  "scenarios": {
+    "basic-ro-list": {
+      "status": "pending",
+      "image": "ext4-basic.img",
+      "mount_args": [],
+      "_attempts": [],
+      "_notes": "Smoke-test for read-only mount + readdir. Uses ext4 ls (CLI) so the same scenario also runs on macOS for cross-host parity if we ever wire that up.",
+      "ops": [
+        {
+          "type": "ls",
+          "path": "/",
+          "expect_names": [
+            ".",
+            "..",
+            "link.txt",
+            "lost+found",
+            "subdir",
+            "test.txt"
+          ]
+        },
+        {
+          "type": "ls",
+          "path": "/subdir",
+          "expect_names": [
+            ".",
+            "..",
+            "nested.txt"
+          ]
+        }
+      ]
+    },
+    "basic-ro-cat": {
+      "status": "pending",
+      "image": "ext4-basic.img",
+      "mount_args": [],
+      "_attempts": [],
+      "_notes": "Verifies read content matches sha256 on a small inline-extent file plus a nested file.",
+      "ops": [
+        {
+          "type": "stat",
+          "path": "/test.txt",
+          "expect_size": 16,
+          "expect_mode": "0o644"
+        },
+        {
+          "type": "cat",
+          "path": "/test.txt",
+          "expect_size": 16,
+          "expect_sha256": "8ce9a8091ad255e6be4b7e9a48f324aea35eb6d9e552628cc139598d97779dee",
+          "expect_content": "hello from ext4\n"
+        },
+        {
+          "type": "cat",
+          "path": "/subdir/nested.txt",
+          "expect_size": 7,
+          "expect_sha256": "370a8c04b8a65bb4494275eec227f1b694db04c76da6b0b8ae88ed1ab19790a3"
+        }
+      ]
+    },
+    "basic-rw-write-readback": {
+      "status": "pending",
+      "image": "ext4-basic.img",
+      "mount_args": [
+        "--rw"
+      ],
+      "_attempts": [],
+      "_notes": "Smallest end-to-end RW round-trip: create file via mounted drive, read it back via same mount. fsck-ext4-strict is requested; for v1 the actual fsck runs Mac-side after diag pull (see TODO in run-scenario.ps1 stage E).",
+      "ops": [
+        {
+          "type": "write",
+          "path": "/new.txt",
+          "content": "hello from windows"
+        },
+        {
+          "type": "cat",
+          "path": "/new.txt",
+          "via": "mount",
+          "expect_content": "hello from windows",
+          "expect_size": 18
+        }
+      ]
+    },
+    "basic-rw-mkdir-touch": {
+      "status": "pending",
+      "image": "ext4-basic.img",
+      "mount_args": [
+        "--rw"
+      ],
+      "_attempts": [],
+      "_notes": "mkdir + create + readdir on the new dir. Catches issues with directory-block linkage on RW.",
+      "ops": [
+        {
+          "type": "mkdir",
+          "path": "/freshdir"
+        },
+        {
+          "type": "write",
+          "path": "/freshdir/inside.txt",
+          "content": "nested write"
+        },
+        {
+          "type": "ls",
+          "path": "/freshdir",
+          "expect_names": [
+            ".",
+            "..",
+            "inside.txt"
+          ]
+        },
+        {
+          "type": "cat",
+          "path": "/freshdir/inside.txt",
+          "via": "mount",
+          "expect_content": "nested write",
+          "expect_size": 12
+        }
+      ]
+    },
+    "htree-listing": {
+      "status": "pending",
+      "image": "ext4-htree.img",
+      "mount_args": [],
+      "_attempts": [],
+      "_notes": "Htree-indexed directory with 256 files + . + .. = 258 entries. Validates the htree iterator end-to-end.",
+      "ops": [
+        {
+          "type": "ls",
+          "path": "/",
+          "expect_names": [
+            ".",
+            "..",
+            "bigdir",
+            "lost+found",
+            "small.txt"
+          ]
+        },
+        {
+          "type": "ls",
+          "path": "/bigdir",
+          "expect_count": 258
+        }
+      ]
+    },
+    "deep-extents-cat": {
+      "status": "pending",
+      "image": "ext4-deep-extents.img",
+      "mount_args": [],
+      "_attempts": [],
+      "_notes": "Files backed by deeper extent trees. Hashes the read against the macOS-captured reference.",
+      "ops": [
+        {
+          "type": "ls",
+          "path": "/",
+          "expect_names": [
+            ".",
+            "..",
+            "dense.txt",
+            "lost+found",
+            "sparse.bin"
+          ]
+        },
+        {
+          "type": "stat",
+          "path": "/dense.txt",
+          "expect_size": 13
+        },
+        {
+          "type": "cat",
+          "path": "/dense.txt",
+          "expect_size": 13,
+          "expect_sha256": "48b29839ecd2a7f7da1326b867961ca050e46fa4035a5f1c7eee28b401646650"
+        }
+      ]
+    },
+    "inline-data-cat": {
+      "status": "pending",
+      "image": "ext4-inline.img",
+      "mount_args": [],
+      "_attempts": [],
+      "_notes": "Inline-data feature exercise. tiny.txt fits inside the inode.",
+      "ops": [
+        {
+          "type": "ls",
+          "path": "/",
+          "expect_names": [
+            ".",
+            "..",
+            "lost+found",
+            "medium.txt",
+            "symlink",
+            "tiny.txt"
+          ]
+        },
+        {
+          "type": "cat",
+          "path": "/tiny.txt",
+          "expect_size": 12,
+          "expect_sha256": "4fa141db5636666c4ba3402bcb80367f847a92174fce57f2b92e912af4411566"
+        }
+      ]
+    },
+    "xattr-getxattr": {
+      "status": "blocked-needs-getxattr-cli",
+      "image": "ext4-xattr.img",
+      "mount_args": [],
+      "_attempts": [],
+      "_notes": "Cannot fully exercise xattrs until ext4.exe grows a `getxattr` subcommand (or the WinFsp adapter exposes xattrs as Windows EAs / ADS). The ls-only operations[] above is a stub so the scenario shape is documented; actual unblock is to add a `getxattr` op type + CLI subcommand. Track in docs/test-harness.md.",
+      "ops": [
+        {
+          "type": "ls",
+          "path": "/",
+          "expect_names": [
+            ".",
+            "..",
+            "lost+found",
+            "plain.txt",
+            "tagged.txt",
+            "tagged_dir"
+          ]
+        }
+      ]
+    },
+    "whole-disk-with-part": {
+      "status": "blocked-needs-test-image-builder",
+      "image": "ext4-whole-disk.img",
+      "mount_args": [
+        "--part",
+        "1"
+      ],
+      "_attempts": [],
+      "_notes": "We don't currently ship a whole-disk (MBR/GPT-wrapped) test image in /Volumes/sdcard256gb/projects/rust-fs-ext4/test-disks/. The existing image-build code lived in earlier git history. Unblock = restore (or re-write) a small wrapper-image builder that produces ext4-whole-disk.img with one ext4 partition and seed it next to the other test disks. Then point this scenario at it.",
+      "ops": [
+        {
+          "type": "ls",
+          "path": "/"
+        }
+      ]
+    }
+  }
+}

--- a/test-matrix.json
+++ b/test-matrix.json
@@ -235,9 +235,334 @@
       "ops": [
         {
           "type": "ls",
-          "path": "/"
+          "path": "/",
+          "extra": "--part 1"
         }
       ]
+    },
+    "basic-stat-test-txt": {
+      "status": "pending",
+      "image": "ext4-basic.img",
+      "mount_args": [],
+      "_attempts": [],
+      "_notes": "Stat shape check on /test.txt via the templated `stat` op. expect_stdout_contains substrings span size/mode/file_type so any drift in stat formatting OR the underlying inode is caught. Capture: ./target/release/ext4 stat ../rust-fs-ext4/test-disks/ext4-basic.img /test.txt",
+      "ops": [
+        {
+          "type": "stat",
+          "path": "/test.txt",
+          "expect_stdout_contains": "size:        16"
+        },
+        {
+          "type": "stat",
+          "path": "/test.txt",
+          "expect_stdout_contains": "mode:        0o644"
+        },
+        {
+          "type": "stat",
+          "path": "/test.txt",
+          "expect_stdout_contains": "file_type:   1"
+        }
+      ]
+    },
+    "basic-stat-symlink": {
+      "status": "pending",
+      "image": "ext4-basic.img",
+      "mount_args": [],
+      "_attempts": [],
+      "_notes": "Symlink coverage. The CLI's `cat` does NOT dereference symlinks (errors with 'not a regular file'); we therefore exercise the link via `stat` instead — file_type 7 = ext4 symlink, size 8 = strlen(\"test.txt\"). Capture: ./target/release/ext4 stat ../rust-fs-ext4/test-disks/ext4-basic.img /link.txt",
+      "ops": [
+        {
+          "type": "stat",
+          "path": "/link.txt",
+          "expect_stdout_contains": "file_type:   7"
+        },
+        {
+          "type": "stat",
+          "path": "/link.txt",
+          "expect_stdout_contains": "size:        8"
+        }
+      ]
+    },
+    "basic-tree-hash": {
+      "status": "pending",
+      "image": "ext4-basic.img",
+      "mount_args": [],
+      "_attempts": [],
+      "_notes": "Recursive tree shape pinned via stdout sha256. ext4 CLI emits LF-only line endings on every platform (Rust println! does not translate on Windows), so the hash is portable. Capture: ./target/release/ext4 tree ../rust-fs-ext4/test-disks/ext4-basic.img | shasum -a 256",
+      "ops": [
+        {
+          "type": "tree",
+          "expect_stdout_sha256": "5cec65ca5ab421cabac1a37a17bbead0df7093f94e8c83eebaa51dcac64218a2"
+        }
+      ]
+    },
+    "basic-info-volume": {
+      "status": "pending",
+      "image": "ext4-basic.img",
+      "mount_args": [],
+      "_attempts": [],
+      "_notes": "Volume-level smoke. Asserts a stable substring (block_size + inode_size) so superblock decoding regressions trip a verdict. Requires the new `info` template added to harness.toml. Capture: ./target/release/ext4 info ../rust-fs-ext4/test-disks/ext4-basic.img",
+      "ops": [
+        {
+          "type": "info",
+          "expect_stdout_contains": "block_size:     4096"
+        },
+        {
+          "type": "info",
+          "expect_stdout_contains": "inode_size:     256"
+        },
+        {
+          "type": "info",
+          "expect_stdout_contains": "label:          \"testvolume\""
+        }
+      ]
+    },
+    "basic-parts-no-table": {
+      "status": "pending",
+      "image": "ext4-basic.img",
+      "mount_args": [],
+      "_attempts": [],
+      "_notes": "Negative path: ext4-basic.img is a bare filesystem with no MBR/GPT. `parts` must exit non-zero. The error text goes to stderr (anyhow), so we assert exit code only. Capture: ./target/release/ext4 parts ../rust-fs-ext4/test-disks/ext4-basic.img ; echo $?  -> 1",
+      "ops": [
+        {
+          "type": "parts",
+          "allow_nonzero_exit": true,
+          "expect_exit": 1
+        }
+      ]
+    },
+    "htree-listing-hash": {
+      "status": "pending",
+      "image": "ext4-htree.img",
+      "mount_args": [],
+      "_attempts": [],
+      "_notes": "Hash the bigdir listing (258 entries). Beats expect_count alone — drift in entry ordering or any single name shifts the hash. Capture: ./target/release/ext4 ls ../rust-fs-ext4/test-disks/ext4-htree.img /bigdir | shasum -a 256",
+      "ops": [
+        {
+          "type": "ls",
+          "path": "/bigdir",
+          "expect_stdout_sha256": "eecb5943cd327c6e4f94bbc8a0f0b27738ced951f4cb3b9235ae37a7313f70da"
+        }
+      ]
+    },
+    "deep-extents-stat": {
+      "status": "pending",
+      "image": "ext4-deep-extents.img",
+      "mount_args": [],
+      "_attempts": [],
+      "_notes": "Verify the sparse.bin file under deeper extent trees: 16 MiB logical size, regular-file type. Pairs with deep-extents-cat (which validates dense.txt content). Capture: ./target/release/ext4 stat ../rust-fs-ext4/test-disks/ext4-deep-extents.img /sparse.bin",
+      "ops": [
+        {
+          "type": "stat",
+          "path": "/sparse.bin",
+          "expect_stdout_contains": "size:        16777216"
+        },
+        {
+          "type": "stat",
+          "path": "/sparse.bin",
+          "expect_stdout_contains": "file_type:   1"
+        }
+      ]
+    },
+    "inline-data-stat": {
+      "status": "pending",
+      "image": "ext4-inline.img",
+      "mount_args": [],
+      "_attempts": [],
+      "_notes": "Stat-side counterpart to inline-data-cat. tiny.txt is 12 bytes ('tiny inline\\n') — small enough to live in the inode. medium.txt overflows inline and falls back to extents. Capture: ./target/release/ext4 stat ../rust-fs-ext4/test-disks/ext4-inline.img /tiny.txt ; ./target/release/ext4 stat ../rust-fs-ext4/test-disks/ext4-inline.img /medium.txt",
+      "ops": [
+        {
+          "type": "stat",
+          "path": "/tiny.txt",
+          "expect_stdout_contains": "size:        12"
+        },
+        {
+          "type": "stat",
+          "path": "/medium.txt",
+          "expect_stdout_contains": "size:        100"
+        }
+      ]
+    },
+    "xattr-cat-content": {
+      "status": "pending",
+      "image": "ext4-xattr.img",
+      "mount_args": [],
+      "_attempts": [],
+      "_notes": "Until the `getxattr` CLI exists (see xattr-getxattr scenario), at least confirm files in an xattr-tagged image still read back correctly via templated cat. tagged.txt body is 'has xattrs\\n' (11 bytes). Capture: ./target/release/ext4 cat ../rust-fs-ext4/test-disks/ext4-xattr.img /tagged.txt | shasum -a 256",
+      "ops": [
+        {
+          "type": "cat",
+          "path": "/tagged.txt",
+          "expect_stdout_sha256": "211681a64dfd209d01a997a527c1706d50945fa2559c1caa289dbb2c1517ebe1"
+        }
+      ]
+    },
+    "whole-disk-parts": {
+      "status": "pending",
+      "image": "ext4-whole-disk.img",
+      "mount_args": [],
+      "_attempts": [],
+      "_notes": "Read the GPT directly (no mount, no --part). One Linux-fs partition at LBA 2048, 32768 sectors. Capture: ./target/release/ext4 parts ../rust-fs-ext4/test-disks/ext4-whole-disk.img",
+      "ops": [
+        {
+          "type": "parts",
+          "expect_stdout_contains": "GPT:linux"
+        },
+        {
+          "type": "parts",
+          "expect_stdout_contains": "2048"
+        }
+      ]
+    },
+    "rw-rename": {
+      "status": "pending",
+      "image": "ext4-basic.img",
+      "mount_args": [
+        "--rw"
+      ],
+      "_attempts": [],
+      "_notes": "RW rename round-trip via the harness's builtin ops: write -> rename -> cat_via_mount. Catches dirent unlink+relink in the parent dir. Capture: content is harness-supplied; size/sha computed from 'rename payload' (15 bytes).",
+      "ops": [
+        {
+          "type": "write",
+          "path": "/before.txt",
+          "content": "rename payload"
+        },
+        {
+          "type": "rename",
+          "from": "/before.txt",
+          "to": "/after.txt"
+        },
+        {
+          "type": "cat_via_mount",
+          "path": "/after.txt",
+          "expect_size": 14,
+          "expect_content": "rename payload",
+          "expect_sha256": "11b27528638c55a418f5e289b0120a0547bdbb7af4baa9f2944ded404d596eb0"
+        }
+      ]
+    },
+    "rw-mkdir-rmdir": {
+      "status": "pending",
+      "image": "ext4-basic.img",
+      "mount_args": [
+        "--rw"
+      ],
+      "_attempts": [],
+      "_notes": "mkdir/rmdir lifecycle. After rmdir the templated `ls /` must NOT include scratch — expect_names is the post-state of the root after rollback, equal to the original basic-ro-list expectation. Captured directly from ./target/release/ext4 ls ../rust-fs-ext4/test-disks/ext4-basic.img /",
+      "ops": [
+        {
+          "type": "mkdir",
+          "path": "/scratch"
+        },
+        {
+          "type": "rmdir",
+          "path": "/scratch"
+        },
+        {
+          "type": "ls",
+          "path": "/",
+          "expect_names": [
+            ".",
+            "..",
+            "link.txt",
+            "lost+found",
+            "subdir",
+            "test.txt"
+          ]
+        }
+      ]
+    },
+    "rw-overwrite": {
+      "status": "pending",
+      "image": "ext4-basic.img",
+      "mount_args": [
+        "--rw"
+      ],
+      "_attempts": [],
+      "_notes": "Overwrite an existing file (test.txt, originally 16 bytes 'hello from ext4\\n') with new shorter content. Validates truncate + rewrite path. Payload 'overwritten' = 11 bytes. sha256 captured via: printf 'overwritten' | shasum -a 256 -> fb428d788e6efaec29dc4a9b3d0b3cf3d2295eb7ffc30f111ac11c4af1dfc118",
+      "ops": [
+        {
+          "type": "write",
+          "path": "/test.txt",
+          "content": "overwritten"
+        },
+        {
+          "type": "cat_via_mount",
+          "path": "/test.txt",
+          "expect_size": 11,
+          "expect_content": "overwritten",
+          "expect_sha256": "fb428d788e6efaec29dc4a9b3d0b3cf3d2295eb7ffc30f111ac11c4af1dfc118"
+        }
+      ]
+    },
+    "rw-unlink": {
+      "status": "pending",
+      "image": "ext4-basic.img",
+      "mount_args": [
+        "--rw"
+      ],
+      "_attempts": [],
+      "_notes": "Create + unlink. After unlink, ls / must match the original 6-entry root (i.e. doomed.txt is gone). Catches inode-leak / dirent-unlink regressions in one shot.",
+      "ops": [
+        {
+          "type": "write",
+          "path": "/doomed.txt",
+          "content": "rm me"
+        },
+        {
+          "type": "unlink",
+          "path": "/doomed.txt"
+        },
+        {
+          "type": "ls",
+          "path": "/",
+          "expect_names": [
+            ".",
+            "..",
+            "link.txt",
+            "lost+found",
+            "subdir",
+            "test.txt"
+          ]
+        }
+      ]
+    },
+    "rw-write-then-readback-via-cli": {
+      "status": "pending",
+      "image": "ext4-basic.img",
+      "mount_args": [
+        "--rw"
+      ],
+      "_attempts": [],
+      "_notes": "Marker scenario for the future post_verify hook (see docs/post-verify-hook.md). Today: write via mount, read back via mount inside the same scenario. Tomorrow: post_verify re-mounts the image RO under the CLI to confirm on-disk durability after the WinFsp host exits. Until then, this scenario covers the in-mount round-trip; the post_verify shape lives in scenario `audit-post-verify-marker` below.",
+      "ops": [
+        {
+          "type": "write",
+          "path": "/persisted.txt",
+          "content": "should survive unmount"
+        },
+        {
+          "type": "cat_via_mount",
+          "path": "/persisted.txt",
+          "expect_size": 22,
+          "expect_content": "should survive unmount"
+        }
+      ]
+    },
+    "watch-volume-arrival-marker": {
+      "status": "blocked-needs-event-injection-harness",
+      "image": "",
+      "mount_args": [],
+      "_attempts": [],
+      "_notes": "Placeholder for `ext4 watch` coverage. The watch subcommand reacts to Windows volume-arrival WMI events; the matrix model has no way to inject one. Unblock requires either (a) a helper that uses VHD attach/detach to synthesize real arrival events on the test VM, or (b) refactoring watch.rs to expose its event handler as a callable function the harness can drive directly. Until then, manual smoke-testing on the VM is the only path."
+    },
+    "installer-msi-marker": {
+      "status": "blocked-needs-msi-test-runner",
+      "image": "",
+      "mount_args": [],
+      "_attempts": [],
+      "_notes": "Placeholder for installer/Bundle.wxs coverage. MSI install + uninstall + right-click verb registration is Windows-only and mutates global state (Program Files, registry, ProgIDs). Unblock requires a sandboxed Windows VM snapshot the harness can revert between runs. Out of scope for the current foreground-mount-driven matrix."
     }
   }
 }

--- a/test-matrix.json
+++ b/test-matrix.json
@@ -224,14 +224,14 @@
       ]
     },
     "whole-disk-with-part": {
-      "status": "blocked-needs-test-image-builder",
+      "status": "pending",
       "image": "ext4-whole-disk.img",
       "mount_args": [
         "--part",
         "1"
       ],
       "_attempts": [],
-      "_notes": "We don't currently ship a whole-disk (MBR/GPT-wrapped) test image in /Volumes/sdcard256gb/projects/rust-fs-ext4/test-disks/. The existing image-build code lived in earlier git history. Unblock = restore (or re-write) a small wrapper-image builder that produces ext4-whole-disk.img with one ext4 partition and seed it next to the other test disks. Then point this scenario at it.",
+      "_notes": "Whole-disk image is built by fixtures/build-whole-disk.py — wraps ext4-basic.img in a GPT layout with one Linux-fs partition starting at LBA 2048.",
       "ops": [
         {
           "type": "ls",

--- a/test-matrix.json
+++ b/test-matrix.json
@@ -563,6 +563,32 @@
       "mount_args": [],
       "_attempts": [],
       "_notes": "Placeholder for installer/Bundle.wxs coverage. MSI install + uninstall + right-click verb registration is Windows-only and mutates global state (Program Files, registry, ProgIDs). Unblock requires a sandboxed Windows VM snapshot the harness can revert between runs. Out of scope for the current foreground-mount-driven matrix."
+    },
+    "audit-post-verify-marker": {
+      "status": "blocked-needs-audit-cli",
+      "image": "ext4-basic.img",
+      "mount_args": [
+        "--rw"
+      ],
+      "_attempts": [],
+      "_notes": "Design marker for the post_verify hook. See docs/post-verify-hook.md. The intended shape (once `ext4 audit <image>` exists) is shown via the post_verify block below — the runner will execute it after a passing RW scenario, after the mount tears down. Today this scenario is parked at status blocked-needs-audit-cli so it doesn't claim time but stays visible when re-reading the matrix.",
+      "ops": [
+        {
+          "type": "write",
+          "path": "/audit-target.txt",
+          "content": "drives the audit command after unmount"
+        },
+        {
+          "type": "cat_via_mount",
+          "path": "/audit-target.txt",
+          "expect_size": 38,
+          "expect_content": "drives the audit command after unmount"
+        }
+      ],
+      "post_verify": {
+        "command": "{binary} audit {image}",
+        "expect_exit": 0
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Bundles the work that built `ext4-win-driver` from "compiles" to "Windows ext4 driver with a real test harness" in this session.

**WinFsp mount path:**
- Read-only mount via WinFsp (`feat: WinFsp read-only mount via patched winfsp-rs fork`) — works against a patched fork of `winfsp-rs` that adds `*-pc-windows-gnullvm` target support; tracking issue / upstream PR is on the fork.
- Read-write mount behind an explicit `--rw` flag (`feat(mount): WinFsp read-write mount via --rw flag`) — wires through `fs_ext4_create / write_file / truncate / unlink / mkdir / rmdir / rename / utimens` from the lib's C ABI.
- `BlockSource` trait + `FileSource` impl with Win32 raw-device handling (`refactor: BlockSource trait`).
- `--part N` partition slicing through `fs_ext4_mount_with_callbacks` (`feat: --part N mounts a GPT/MBR partition via callback shim`).

**Auto-mount + installer:**
- `ext4 watch` Windows-only subcommand using `RegisterDeviceNotificationW` + a hidden message-only window to auto-spawn `ext4 mount` on volume arrival (`feat(watch): auto-mount ext4 volumes on Windows volume arrival`).
- WiX 4 MSI installer with right-click "Mount as ext4" verb on `.img` files (`feat(installer): WiX 4 MSI + .img right-click verb`).

**Test harness:**
- Migrated from an in-tree harness scaffold to the shared `fs-test-harness` (`test(harness): consume shared fs-test-harness`).
- Vendored as a git submodule at `./harness` (`chore: switch fs-test-harness to a git submodule`).
- 27 scenarios in `test-matrix.json` covering basic / htree / deep-extents / inline / xattr / RW round-trips / partition slicing. 23 pending, 4 blocked with documented unblockers.
- Whole-disk fixture builder (`test(harness): ship whole-disk fixture builder`).
- Post-verify hook design doc at `docs/post-verify-hook.md`.

End-to-end verified on Windows 11 ARM64 (`aarch64-pc-windows-gnullvm` + WinFsp 2.1): full 27-scenario matrix runs Mac → SSH → VM → diag pull, 23/23 of the active scenarios green.

## Test plan

- [ ] `cargo build --release` (CLI only, all platforms)
- [ ] `cargo build --release --features mount` on Windows ARM64 with LLVM-MinGW + LLVM + WinFsp 2.1 installed
- [ ] `cargo test`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `bash harness/scripts/test-windows-matrix.sh` against the canonical Windows VM (full matrix)
- [ ] `bash harness/scripts/test-windows-matrix.sh basic-ro-list` (single-scenario smoke)
- [ ] Manual: install the MSI on a clean Windows machine, right-click an `.img` to mount, browse in Explorer, eject

## Notes for the reviewer

- The harness submodule pin (`harness/`) tracks `antimatter-studios/fs-test-harness@d89d8b3` (CI green: 4/4).
- The library dependency `fs-ext4 = { path = "../rust-fs-ext4" }` and `winfsp` path-dep on the local fork are sibling-repo-only — neither is on a remote we can publish to from this PR. They become formal deps when those projects land on GitHub.
- `installer/` working-tree edits are intentionally NOT in this PR; they're separate in-flight work outside this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
