### PR TITLE
feat: ext4 driver staging-2 — write ops, xattrs/EAs, stat improvements, fallocate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "caseless"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
+dependencies = [
+ "unicode-normalization",
+]
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "ext4-win-driver"
@@ -250,7 +259,9 @@ version = "0.2.1"
 dependencies = [
  "am-fs-core",
  "bitflags",
+ "caseless",
  "crc32c",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -307,15 +318,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "minimal-lexical"
@@ -325,9 +336,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -544,10 +555,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "utf8parse"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -659,9 +659,17 @@ pub fn write_file(mt: &MountArgs, path: &str) -> Result<()> {
     let cp = CString::new(path).context("path contains NUL byte")?;
     let mut data = Vec::new();
     std::io::stdin().read_to_end(&mut data).context("reading stdin")?;
-    // Use pwrite at offset 0 to overwrite; fs_ext4_pwrite allocates blocks
-    // only for the written range so it works on both new and existing files.
-    // Truncate to the written length first so any existing tail is removed.
+
+    // Create the file if it doesn't exist yet (fs_ext4_truncate fails on ENOENT).
+    let mut attr: fs_ext4_attr_t = unsafe { std::mem::zeroed() };
+    let exists = unsafe { fs_ext4_stat(m.fs, cp.as_ptr(), &mut attr) } == 0;
+    if !exists {
+        let ino = unsafe { fs_ext4_create(m.fs, cp.as_ptr(), 0o644) };
+        if ino == 0 {
+            bail!("create({path:?}) failed: {}", last_err());
+        }
+    }
+
     let rc = unsafe { fs_ext4_truncate(m.fs, cp.as_ptr(), 0) };
     if rc != 0 {
         bail!("truncate({path:?}, 0) failed: {}", last_err());
@@ -679,6 +687,40 @@ pub fn write_file(mt: &MountArgs, path: &str) -> Result<()> {
         if written < 0 {
             bail!("pwrite({path:?}) failed: {}", last_err());
         }
+    }
+    Ok(())
+}
+
+pub fn touch(mt: &MountArgs, path: &str) -> Result<()> {
+    let m = Mount::open_rw(mt)?;
+    let cp = CString::new(path).context("path contains NUL byte")?;
+    let mut attr: fs_ext4_attr_t = unsafe { std::mem::zeroed() };
+    let exists = unsafe { fs_ext4_stat(m.fs, cp.as_ptr(), &mut attr) } == 0;
+    if !exists {
+        let ino = unsafe { fs_ext4_create(m.fs, cp.as_ptr(), 0o644) };
+        if ino == 0 {
+            bail!("create({path:?}) failed: {}", last_err());
+        }
+    }
+    Ok(())
+}
+
+pub fn chmod(mt: &MountArgs, path: &str, mode: u32) -> Result<()> {
+    let m = Mount::open_rw(mt)?;
+    let cp = CString::new(path).context("path contains NUL byte")?;
+    let rc = unsafe { fs_ext4_chmod(m.fs, cp.as_ptr(), mode as u16) };
+    if rc != 0 {
+        bail!("chmod({path:?}, {mode:#o}) failed: {}", last_err());
+    }
+    Ok(())
+}
+
+pub fn chown(mt: &MountArgs, path: &str, uid: u32, gid: u32) -> Result<()> {
+    let m = Mount::open_rw(mt)?;
+    let cp = CString::new(path).context("path contains NUL byte")?;
+    let rc = unsafe { fs_ext4_chown(m.fs, cp.as_ptr(), uid, gid) };
+    if rc != 0 {
+        bail!("chown({path:?}, {uid}, {gid}) failed: {}", last_err());
     }
     Ok(())
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -327,7 +327,7 @@ fn resolve_symlink(m: &Mount, path: &str) -> Result<String> {
     bail!("symlink loop or depth > 8: {path:?}")
 }
 
-pub fn cat(mt: &MountArgs, path: &str) -> Result<()> {
+pub fn cat(mt: &MountArgs, path: &str, offset: u64, length: Option<u64>) -> Result<()> {
     use std::io::Write;
 
     let m = Mount::open(mt)?;
@@ -338,21 +338,25 @@ pub fn cat(mt: &MountArgs, path: &str) -> Result<()> {
     if unsafe { fs_ext4_stat(m.fs, cp.as_ptr(), &mut attr) } != 0 {
         bail!("stat({resolved:?}) failed: {}", last_err());
     }
-    if attr.size == 0 {
+
+    let end = length
+        .map(|l| (offset + l).min(attr.size))
+        .unwrap_or(attr.size);
+    if offset >= end {
         return Ok(());
     }
 
     let mut stdout = std::io::stdout().lock();
-    let mut offset: u64 = 0;
+    let mut pos = offset;
     let mut buf = vec![0u8; 64 * 1024];
-    while offset < attr.size {
-        let want = std::cmp::min(buf.len() as u64, attr.size - offset);
+    while pos < end {
+        let want = std::cmp::min(buf.len() as u64, end - pos);
         let n = unsafe {
             fs_ext4_read_file(
                 m.fs,
                 cp.as_ptr(),
                 buf.as_mut_ptr() as *mut c_void,
-                offset,
+                pos,
                 want,
             )
         };
@@ -363,7 +367,7 @@ pub fn cat(mt: &MountArgs, path: &str) -> Result<()> {
             break;
         }
         stdout.write_all(&buf[..n as usize])?;
-        offset += n as u64;
+        pos += n as u64;
     }
     Ok(())
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -830,3 +830,17 @@ pub fn rename(mt: &MountArgs, src: &str, dst: &str) -> Result<()> {
     }
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// fallocate
+// ---------------------------------------------------------------------------
+
+pub fn fallocate(mt: &MountArgs, path: &str, offset: u64, len: u64, flags: i32) -> Result<()> {
+    let m = Mount::open_rw(mt)?;
+    let cp = CString::new(path).context("path contains NUL byte")?;
+    let rc = unsafe { fs_ext4_fallocate(m.fs, cp.as_ptr(), offset, len, flags) };
+    if rc != 0 {
+        bail!("fallocate({path:?}, offset={offset}, len={len}, flags={flags:#x}) failed: {}", last_err());
+    }
+    Ok(())
+}

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -51,6 +51,60 @@ fn ftype_str(ft: u8) -> &'static str {
     }
 }
 
+/// Format a POSIX mode integer as an `ls -l`-style string (e.g. `drwxr-xr-x`).
+fn format_mode_str(mode: u16, file_type: &fs_ext4_file_type_t) -> String {
+    let type_char = match file_type {
+        fs_ext4_file_type_t::RegFile => '-',
+        fs_ext4_file_type_t::Dir     => 'd',
+        fs_ext4_file_type_t::Symlink => 'l',
+        fs_ext4_file_type_t::ChrDev  => 'c',
+        fs_ext4_file_type_t::BlkDev  => 'b',
+        fs_ext4_file_type_t::Fifo    => 'p',
+        fs_ext4_file_type_t::Sock    => 's',
+        _                            => '?',
+    };
+    let setuid = mode & 0o4000 != 0;
+    let setgid = mode & 0o2000 != 0;
+    let sticky = mode & 0o1000 != 0;
+    let bit = |mask: u16, c: char, alt: char| if mode & mask != 0 { c } else { alt };
+    format!(
+        "{}{}{}{}{}{}{}{}{}{}", type_char,
+        bit(0o400, 'r', '-'), bit(0o200, 'w', '-'),
+        if setuid { if mode & 0o100 != 0 { 's' } else { 'S' } } else { bit(0o100, 'x', '-') },
+        bit(0o040, 'r', '-'), bit(0o020, 'w', '-'),
+        if setgid { if mode & 0o010 != 0 { 's' } else { 'S' } } else { bit(0o010, 'x', '-') },
+        bit(0o004, 'r', '-'), bit(0o002, 'w', '-'),
+        if sticky { if mode & 0o001 != 0 { 't' } else { 'T' } } else { bit(0o001, 'x', '-') },
+    )
+}
+
+/// Format a Unix timestamp (seconds since epoch) as a compact UTC string.
+fn format_unix_time(secs: u32) -> String {
+    // Days from epoch; compute year/month/day via the proleptic Gregorian calendar.
+    let s = secs as u64;
+    let (sec, s) = (s % 60, s / 60);
+    let (min, s) = (s % 60, s / 60);
+    let (hour, mut days) = (s % 24, s / 24);
+    // Algorithm: days since 1970-01-01
+    let mut year = 1970u32;
+    loop {
+        let leap = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+        let dy = if leap { 366 } else { 365 };
+        if days < dy { break; }
+        days -= dy;
+        year += 1;
+    }
+    let leap = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+    let months = [31u64, if leap { 29 } else { 28 }, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let mut month = 1u32;
+    for m in &months {
+        if days < *m { break; }
+        days -= m;
+        month += 1;
+    }
+    format!("{year:04}-{month:02}-{:02}T{hour:02}:{min:02}:{sec:02}Z", days + 1)
+}
+
 fn format_uuid(u: &[u8; 16]) -> String {
     format!(
         "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
@@ -226,17 +280,18 @@ pub fn stat(mt: &MountArgs, path: &str) -> Result<()> {
     if r != 0 {
         bail!("stat({path:?}) failed: {}", last_err());
     }
+    let mode_str = format_mode_str(attr.mode, &attr.file_type);
     println!("path:        {path}");
     println!("inode:       {}", attr.inode);
     println!("size:        {}", attr.size);
-    println!("mode:        0o{:o}", attr.mode);
+    println!("mode:        {mode_str}  (0o{:o})", attr.mode & 0o7777);
     println!("uid/gid:     {}/{}", attr.uid, attr.gid);
     println!("link_count:  {}", attr.link_count);
-    println!("atime:       {}", attr.atime);
-    println!("mtime:       {}", attr.mtime);
-    println!("ctime:       {}", attr.ctime);
-    println!("crtime:      {}", attr.crtime);
-    println!("file_type:   {:?}", attr.file_type as u32);
+    println!("atime:       {} ({})", attr.atime, format_unix_time(attr.atime));
+    println!("mtime:       {} ({})", attr.mtime, format_unix_time(attr.mtime));
+    println!("ctime:       {} ({})", attr.ctime, format_unix_time(attr.ctime));
+    println!("crtime:      {} ({})", attr.crtime, format_unix_time(attr.crtime));
+    println!("type:        {:?}", attr.file_type);
     Ok(())
 }
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -787,6 +787,16 @@ pub fn chown(mt: &MountArgs, path: &str, uid: u32, gid: u32) -> Result<()> {
     Ok(())
 }
 
+pub fn setflags(mt: &MountArgs, path: &str, flags: u32) -> Result<()> {
+    let m = Mount::open_rw(mt)?;
+    let cp = CString::new(path).context("path contains NUL byte")?;
+    let rc = unsafe { fs_ext4_set_flags(m.fs, cp.as_ptr(), flags) };
+    if rc != 0 {
+        bail!("set_flags({path:?}, 0x{flags:08x}) failed: {}", last_err());
+    }
+    Ok(())
+}
+
 pub fn mkdir(mt: &MountArgs, path: &str) -> Result<()> {
     let m = Mount::open_rw(mt)?;
     let cp = CString::new(path).context("path contains NUL byte")?;

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -287,10 +287,13 @@ pub fn stat(mt: &MountArgs, path: &str) -> Result<()> {
     println!("mode:        {mode_str}  (0o{:o})", attr.mode & 0o7777);
     println!("uid/gid:     {}/{}", attr.uid, attr.gid);
     println!("link_count:  {}", attr.link_count);
-    println!("atime:       {} ({})", attr.atime, format_unix_time(attr.atime));
-    println!("mtime:       {} ({})", attr.mtime, format_unix_time(attr.mtime));
-    println!("ctime:       {} ({})", attr.ctime, format_unix_time(attr.ctime));
-    println!("crtime:      {} ({})", attr.crtime, format_unix_time(attr.crtime));
+    println!("inode_flags: 0x{:08x}", attr.inode_flags);
+    println!("generation:  {}", attr.generation);
+    println!("blocks_512:  {}", attr.blocks_512);
+    println!("atime:       {}.{:09} ({})", attr.atime, attr.atime_nsec, format_unix_time(attr.atime));
+    println!("mtime:       {}.{:09} ({})", attr.mtime, attr.mtime_nsec, format_unix_time(attr.mtime));
+    println!("ctime:       {}.{:09} ({})", attr.ctime, attr.ctime_nsec, format_unix_time(attr.ctime));
+    println!("crtime:      {}.{:09} ({})", attr.crtime, attr.crtime_nsec, format_unix_time(attr.crtime));
     println!("type:        {:?}", attr.file_type);
     Ok(())
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -648,3 +648,88 @@ pub fn link(mt: &MountArgs, src: &str, dst: &str) -> Result<()> {
     }
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// write / mkdir / rmdir / unlink / truncate  (mutating CLI ops)
+// ---------------------------------------------------------------------------
+
+pub fn write_file(mt: &MountArgs, path: &str) -> Result<()> {
+    use std::io::Read;
+    let m = Mount::open_rw(mt)?;
+    let cp = CString::new(path).context("path contains NUL byte")?;
+    let mut data = Vec::new();
+    std::io::stdin().read_to_end(&mut data).context("reading stdin")?;
+    // Use pwrite at offset 0 to overwrite; fs_ext4_pwrite allocates blocks
+    // only for the written range so it works on both new and existing files.
+    // Truncate to the written length first so any existing tail is removed.
+    let rc = unsafe { fs_ext4_truncate(m.fs, cp.as_ptr(), 0) };
+    if rc != 0 {
+        bail!("truncate({path:?}, 0) failed: {}", last_err());
+    }
+    if !data.is_empty() {
+        let written = unsafe {
+            fs_ext4_pwrite(
+                m.fs,
+                cp.as_ptr(),
+                data.as_ptr() as *const c_void,
+                data.len(),
+                0,
+            )
+        };
+        if written < 0 {
+            bail!("pwrite({path:?}) failed: {}", last_err());
+        }
+    }
+    Ok(())
+}
+
+pub fn mkdir(mt: &MountArgs, path: &str) -> Result<()> {
+    let m = Mount::open_rw(mt)?;
+    let cp = CString::new(path).context("path contains NUL byte")?;
+    let rc = unsafe { fs_ext4_mkdir(m.fs, cp.as_ptr(), 0o755) };
+    if rc != 0 {
+        bail!("mkdir({path:?}) failed: {}", last_err());
+    }
+    Ok(())
+}
+
+pub fn rmdir(mt: &MountArgs, path: &str) -> Result<()> {
+    let m = Mount::open_rw(mt)?;
+    let cp = CString::new(path).context("path contains NUL byte")?;
+    let rc = unsafe { fs_ext4_rmdir(m.fs, cp.as_ptr()) };
+    if rc != 0 {
+        bail!("rmdir({path:?}) failed: {}", last_err());
+    }
+    Ok(())
+}
+
+pub fn unlink(mt: &MountArgs, path: &str) -> Result<()> {
+    let m = Mount::open_rw(mt)?;
+    let cp = CString::new(path).context("path contains NUL byte")?;
+    let rc = unsafe { fs_ext4_unlink(m.fs, cp.as_ptr()) };
+    if rc != 0 {
+        bail!("unlink({path:?}) failed: {}", last_err());
+    }
+    Ok(())
+}
+
+pub fn truncate(mt: &MountArgs, path: &str, size: u64) -> Result<()> {
+    let m = Mount::open_rw(mt)?;
+    let cp = CString::new(path).context("path contains NUL byte")?;
+    let rc = unsafe { fs_ext4_truncate(m.fs, cp.as_ptr(), size) };
+    if rc != 0 {
+        bail!("truncate({path:?}, {size}) failed: {}", last_err());
+    }
+    Ok(())
+}
+
+pub fn rename(mt: &MountArgs, src: &str, dst: &str) -> Result<()> {
+    let m = Mount::open_rw(mt)?;
+    let cs = CString::new(src).context("src contains NUL byte")?;
+    let cd = CString::new(dst).context("dst contains NUL byte")?;
+    let rc = unsafe { fs_ext4_rename2(m.fs, cs.as_ptr(), cd.as_ptr(), 0) };
+    if rc != 0 {
+        bail!("rename({src:?} -> {dst:?}) failed: {}", last_err());
+    }
+    Ok(())
+}

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -797,6 +797,16 @@ pub fn setflags(mt: &MountArgs, path: &str, flags: u32) -> Result<()> {
     Ok(())
 }
 
+pub fn mknod(mt: &MountArgs, path: &str, mode: u16, major: u32, minor: u32) -> Result<()> {
+    let m = Mount::open_rw(mt)?;
+    let cp = CString::new(path).context("path contains NUL byte")?;
+    let rc = unsafe { fs_ext4_mknod(m.fs, cp.as_ptr(), mode, major, minor) };
+    if rc == 0 {
+        bail!("mknod({path:?}, mode=0o{mode:o}, {major}:{minor}) failed: {}", last_err());
+    }
+    Ok(())
+}
+
 pub fn mkdir(mt: &MountArgs, path: &str) -> Result<()> {
     let m = Mount::open_rw(mt)?;
     let cp = CString::new(path).context("path contains NUL byte")?;

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -587,3 +587,64 @@ pub fn getxattr(mt: &MountArgs, path: &str, name: &str) -> Result<()> {
     std::io::stdout().lock().write_all(&buf[..n as usize])?;
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// setxattr / removexattr
+// ---------------------------------------------------------------------------
+
+pub fn setxattr(mt: &MountArgs, path: &str, name: &str, value: &[u8]) -> Result<()> {
+    let m = Mount::open_rw(mt)?;
+    let cp = CString::new(path).context("path contains NUL byte")?;
+    let cn = CString::new(name).context("name contains NUL byte")?;
+    let rc = unsafe {
+        fs_ext4_setxattr(
+            m.fs,
+            cp.as_ptr(),
+            cn.as_ptr(),
+            value.as_ptr() as *const c_void,
+            value.len(),
+        )
+    };
+    if rc != 0 {
+        bail!("setxattr({path:?}, {name:?}) failed: {}", last_err());
+    }
+    Ok(())
+}
+
+pub fn removexattr(mt: &MountArgs, path: &str, name: &str) -> Result<()> {
+    let m = Mount::open_rw(mt)?;
+    let cp = CString::new(path).context("path contains NUL byte")?;
+    let cn = CString::new(name).context("name contains NUL byte")?;
+    let rc = unsafe { fs_ext4_removexattr(m.fs, cp.as_ptr(), cn.as_ptr()) };
+    if rc != 0 {
+        bail!("removexattr({path:?}, {name:?}) failed: {}", last_err());
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// symlink / link
+// ---------------------------------------------------------------------------
+
+pub fn symlink(mt: &MountArgs, target: &str, linkpath: &str) -> Result<()> {
+    let m = Mount::open_rw(mt)?;
+    let ct = CString::new(target).context("target contains NUL byte")?;
+    let cl = CString::new(linkpath).context("linkpath contains NUL byte")?;
+    // fs_ext4_symlink returns the new inode number (>0) on success, 0 on failure.
+    let ino = unsafe { fs_ext4_symlink(m.fs, ct.as_ptr(), cl.as_ptr()) };
+    if ino == 0 {
+        bail!("symlink({target:?} -> {linkpath:?}) failed: {}", last_err());
+    }
+    Ok(())
+}
+
+pub fn link(mt: &MountArgs, src: &str, dst: &str) -> Result<()> {
+    let m = Mount::open_rw(mt)?;
+    let cs = CString::new(src).context("src contains NUL byte")?;
+    let cd = CString::new(dst).context("dst contains NUL byte")?;
+    let rc = unsafe { fs_ext4_link(m.fs, cs.as_ptr(), cd.as_ptr()) };
+    if rc != 0 {
+        bail!("link({src:?} -> {dst:?}) failed: {}", last_err());
+    }
+    Ok(())
+}

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -742,12 +742,15 @@ pub fn write_file(mt: &MountArgs, path: &str) -> Result<()> {
                 m.fs,
                 cp.as_ptr(),
                 data.as_ptr() as *const c_void,
-                data.len(),
+                data.len() as u64,
                 0,
             )
         };
         if written < 0 {
             bail!("pwrite({path:?}) failed: {}", last_err());
+        }
+        if written < data.len() as i64 {
+            bail!("pwrite({path:?}): short write ({written} < {})", data.len());
         }
     }
     Ok(())
@@ -801,7 +804,7 @@ pub fn mknod(mt: &MountArgs, path: &str, mode: u16, major: u32, minor: u32) -> R
     let m = Mount::open_rw(mt)?;
     let cp = CString::new(path).context("path contains NUL byte")?;
     let rc = unsafe { fs_ext4_mknod(m.fs, cp.as_ptr(), mode, major, minor) };
-    if rc == 0 {
+    if rc != 0 {
         bail!("mknod({path:?}, mode=0o{mode:o}, {major}:{minor}) failed: {}", last_err());
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,15 @@ use anyhow::Result;
 use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
 
+/// Parse `0x...` hex or plain decimal u32 for clap `--value-parser`.
+fn parse_hex_or_dec(s: &str) -> Result<u32, String> {
+    if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        u32::from_str_radix(hex, 16).map_err(|e| e.to_string())
+    } else {
+        s.parse::<u32>().map_err(|e| e.to_string())
+    }
+}
+
 use winfsp_fs_skeleton::FsBackend;
 
 mod cmd;
@@ -261,6 +270,17 @@ enum Cmd {
         uid: u32,
         gid: u32,
     },
+    /// Set inode flags (FS_IOC_SETFLAGS). `flags` is the full new flags word
+    /// in decimal or hex (prefix `0x`). Common values:
+    ///   0x10 = IMMUTABLE, 0x20 = APPEND_ONLY, 0x40 = NODUMP, 0x200 = NOATIME.
+    Setflags {
+        #[command(flatten)]
+        mt: MountArgs,
+        path: String,
+        /// New flags value (hex with 0x prefix or decimal).
+        #[arg(value_parser = parse_hex_or_dec)]
+        flags: u32,
+    },
     /// Pre-allocate or punch a hole in a file.
     /// Flags: 0 = pre-allocate (may extend size), 1 = keep-size,
     /// 3 = punch-hole+keep-size, 16 = zero-range.
@@ -352,6 +372,7 @@ fn main() -> Result<()> {
         Cmd::Touch { mt, path } => cmd::touch(&mt, &path),
         Cmd::Chmod { mt, path, mode } => cmd::chmod(&mt, &path, mode),
         Cmd::Chown { mt, path, uid, gid } => cmd::chown(&mt, &path, uid, gid),
+        Cmd::Setflags { mt, path, flags } => cmd::setflags(&mt, &path, flags),
         Cmd::Fallocate { mt, path, offset, len, flags } => cmd::fallocate(&mt, &path, offset, len, flags),
         #[cfg(all(windows, feature = "mount"))]
         Cmd::Mount {

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,6 +148,48 @@ enum Cmd {
         path: String,
         name: String,
     },
+    /// Set (create or replace) an extended attribute. The value is taken from
+    /// the `--value` flag (UTF-8 string) or from stdin when `--stdin` is set.
+    /// The name must include its namespace prefix (e.g. `user.myattr`).
+    Setxattr {
+        #[command(flatten)]
+        mt: MountArgs,
+        path: String,
+        name: String,
+        /// Attribute value as a UTF-8 string.
+        #[arg(long, conflicts_with = "stdin")]
+        value: Option<String>,
+        /// Read attribute value from stdin (binary-safe).
+        #[arg(long)]
+        stdin: bool,
+    },
+    /// Remove an extended attribute. The name must include its namespace prefix.
+    Removexattr {
+        #[command(flatten)]
+        mt: MountArgs,
+        path: String,
+        name: String,
+    },
+    /// Create a symbolic link. `target` is the link content (what the symlink
+    /// points at); `linkpath` is the path of the new symlink inode.
+    Symlink {
+        #[command(flatten)]
+        mt: MountArgs,
+        /// What the symlink points at (the stored target string).
+        target: String,
+        /// Path of the new symlink inode to create.
+        linkpath: String,
+    },
+    /// Create a hard link: `dst` becomes a new directory entry pointing at
+    /// the same inode as `src`.
+    Link {
+        #[command(flatten)]
+        mt: MountArgs,
+        /// Existing file path (the inode to link to).
+        src: String,
+        /// New path to create.
+        dst: String,
+    },
     /// Mount the filesystem on a Windows drive letter via WinFsp.
     /// Defaults to read-write; pass `--ro` for read-only. Requires the
     /// `mount` feature and a Windows host.
@@ -204,6 +246,20 @@ fn main() -> Result<()> {
         Cmd::Readlink { mt, path } => cmd::readlink(&mt, &path),
         Cmd::Listxattr { mt, path } => cmd::listxattr(&mt, &path),
         Cmd::Getxattr { mt, path, name } => cmd::getxattr(&mt, &path, &name),
+        Cmd::Setxattr { mt, path, name, value, stdin } => {
+            let bytes = if stdin {
+                use std::io::Read;
+                let mut buf = Vec::new();
+                std::io::stdin().read_to_end(&mut buf)?;
+                buf
+            } else {
+                value.unwrap_or_default().into_bytes()
+            };
+            cmd::setxattr(&mt, &path, &name, &bytes)
+        }
+        Cmd::Removexattr { mt, path, name } => cmd::removexattr(&mt, &path, &name),
+        Cmd::Symlink { mt, target, linkpath } => cmd::symlink(&mt, &target, &linkpath),
+        Cmd::Link { mt, src, dst } => cmd::link(&mt, &src, &dst),
         #[cfg(all(windows, feature = "mount"))]
         Cmd::Mount {
             mt,

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,6 +255,18 @@ enum Cmd {
         uid: u32,
         gid: u32,
     },
+    /// Pre-allocate or punch a hole in a file.
+    /// Flags: 0 = pre-allocate (may extend size), 1 = keep-size,
+    /// 3 = punch-hole+keep-size, 16 = zero-range.
+    Fallocate {
+        #[command(flatten)]
+        mt: MountArgs,
+        path: String,
+        offset: u64,
+        len: u64,
+        #[arg(long, default_value_t = 0)]
+        flags: i32,
+    },
     /// Mount the filesystem on a Windows drive letter via WinFsp.
     /// Defaults to read-write; pass `--ro` for read-only. Requires the
     /// `mount` feature and a Windows host.
@@ -334,6 +346,7 @@ fn main() -> Result<()> {
         Cmd::Touch { mt, path } => cmd::touch(&mt, &path),
         Cmd::Chmod { mt, path, mode } => cmd::chmod(&mt, &path, mode),
         Cmd::Chown { mt, path, uid, gid } => cmd::chown(&mt, &path, uid, gid),
+        Cmd::Fallocate { mt, path, offset, len, flags } => cmd::fallocate(&mt, &path, offset, len, flags),
         #[cfg(all(windows, feature = "mount"))]
         Cmd::Mount {
             mt,

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,6 +281,25 @@ enum Cmd {
         #[arg(value_parser = parse_hex_or_dec)]
         flags: u32,
     },
+    /// Create a special file: FIFO (named pipe), socket, char device, or
+    /// block device. `mode` includes type bits + permissions in octal
+    /// (e.g. 0o10644 for a FIFO with 0644 perms). `major` and `minor` are
+    /// device numbers for char/block devices; omit (or pass 0) for FIFO/socket.
+    Mknod {
+        #[command(flatten)]
+        mt: MountArgs,
+        path: String,
+        /// File type + permission bits in octal (e.g. 0o10644 = FIFO|0644).
+        /// Type bits: FIFO=0o10000, socket=0o140000, char=0o20000, blk=0o60000.
+        #[arg(value_parser = parse_hex_or_dec)]
+        mode: u32,
+        /// Major device number (0 for FIFO / socket).
+        #[arg(default_value_t = 0)]
+        major: u32,
+        /// Minor device number (0 for FIFO / socket).
+        #[arg(default_value_t = 0)]
+        minor: u32,
+    },
     /// Pre-allocate or punch a hole in a file.
     /// Flags: 0 = pre-allocate (may extend size), 1 = keep-size,
     /// 3 = punch-hole+keep-size, 16 = zero-range.
@@ -373,6 +392,7 @@ fn main() -> Result<()> {
         Cmd::Chmod { mt, path, mode } => cmd::chmod(&mt, &path, mode),
         Cmd::Chown { mt, path, uid, gid } => cmd::chown(&mt, &path, uid, gid),
         Cmd::Setflags { mt, path, flags } => cmd::setflags(&mt, &path, flags),
+        Cmd::Mknod { mt, path, mode, major, minor } => cmd::mknod(&mt, &path, mode as u16, major, minor),
         Cmd::Fallocate { mt, path, offset, len, flags } => cmd::fallocate(&mt, &path, offset, len, flags),
         #[cfg(all(windows, feature = "mount"))]
         Cmd::Mount {

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,6 +190,46 @@ enum Cmd {
         /// New path to create.
         dst: String,
     },
+    /// Write stdin to a file (creates or overwrites). Reads until EOF,
+    /// truncates the file to the written length.
+    Write {
+        #[command(flatten)]
+        mt: MountArgs,
+        path: String,
+    },
+    /// Create a directory (mode 0755).
+    Mkdir {
+        #[command(flatten)]
+        mt: MountArgs,
+        path: String,
+    },
+    /// Remove an empty directory.
+    Rmdir {
+        #[command(flatten)]
+        mt: MountArgs,
+        path: String,
+    },
+    /// Remove a file (not a directory).
+    Unlink {
+        #[command(flatten)]
+        mt: MountArgs,
+        path: String,
+    },
+    /// Truncate a file to the given byte length.
+    Truncate {
+        #[command(flatten)]
+        mt: MountArgs,
+        path: String,
+        size: u64,
+    },
+    /// Rename / move `src` to `dst`. Destination must not already exist;
+    /// use `--replace` to atomically overwrite an existing destination.
+    Rename {
+        #[command(flatten)]
+        mt: MountArgs,
+        src: String,
+        dst: String,
+    },
     /// Mount the filesystem on a Windows drive letter via WinFsp.
     /// Defaults to read-write; pass `--ro` for read-only. Requires the
     /// `mount` feature and a Windows host.
@@ -260,6 +300,12 @@ fn main() -> Result<()> {
         Cmd::Removexattr { mt, path, name } => cmd::removexattr(&mt, &path, &name),
         Cmd::Symlink { mt, target, linkpath } => cmd::symlink(&mt, &target, &linkpath),
         Cmd::Link { mt, src, dst } => cmd::link(&mt, &src, &dst),
+        Cmd::Write { mt, path } => cmd::write_file(&mt, &path),
+        Cmd::Mkdir { mt, path } => cmd::mkdir(&mt, &path),
+        Cmd::Rmdir { mt, path } => cmd::rmdir(&mt, &path),
+        Cmd::Unlink { mt, path } => cmd::unlink(&mt, &path),
+        Cmd::Truncate { mt, path, size } => cmd::truncate(&mt, &path, size),
+        Cmd::Rename { mt, src, dst } => cmd::rename(&mt, &src, &dst),
         #[cfg(all(windows, feature = "mount"))]
         Cmd::Mount {
             mt,

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,6 +230,31 @@ enum Cmd {
         src: String,
         dst: String,
     },
+    /// Create a file if it doesn't exist (like `touch`). Does not modify
+    /// an existing file.
+    Touch {
+        #[command(flatten)]
+        mt: MountArgs,
+        path: String,
+    },
+    /// Change file permissions. `mode` is an octal integer (e.g. 644).
+    Chmod {
+        #[command(flatten)]
+        mt: MountArgs,
+        path: String,
+        /// Octal mode (e.g. 755). Parsed as decimal by the shell; prefix
+        /// with `0o` for an explicit octal literal if your shell allows it,
+        /// or pass the decimal equivalent (e.g. 493 for 0755).
+        mode: u32,
+    },
+    /// Change file owner / group.
+    Chown {
+        #[command(flatten)]
+        mt: MountArgs,
+        path: String,
+        uid: u32,
+        gid: u32,
+    },
     /// Mount the filesystem on a Windows drive letter via WinFsp.
     /// Defaults to read-write; pass `--ro` for read-only. Requires the
     /// `mount` feature and a Windows host.
@@ -306,6 +331,9 @@ fn main() -> Result<()> {
         Cmd::Unlink { mt, path } => cmd::unlink(&mt, &path),
         Cmd::Truncate { mt, path, size } => cmd::truncate(&mt, &path, size),
         Cmd::Rename { mt, src, dst } => cmd::rename(&mt, &src, &dst),
+        Cmd::Touch { mt, path } => cmd::touch(&mt, &path),
+        Cmd::Chmod { mt, path, mode } => cmd::chmod(&mt, &path, mode),
+        Cmd::Chown { mt, path, uid, gid } => cmd::chown(&mt, &path, uid, gid),
         #[cfg(all(windows, feature = "mount"))]
         Cmd::Mount {
             mt,

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,11 +99,17 @@ enum Cmd {
         mt: MountArgs,
         path: String,
     },
-    /// Print a file's contents to stdout.
+    /// Print a file's contents to stdout. Follows symlinks.
     Cat {
         #[command(flatten)]
         mt: MountArgs,
         path: String,
+        /// Byte offset to start reading from (default: 0).
+        #[arg(long, default_value_t = 0)]
+        offset: u64,
+        /// Maximum number of bytes to read (default: read to EOF).
+        #[arg(long)]
+        length: Option<u64>,
     },
     /// Recursive tree listing from /.
     Tree {
@@ -312,7 +318,7 @@ fn main() -> Result<()> {
             expect_count,
         } => cmd::verify_ls(&mt, &path, &expect_names, expect_count),
         Cmd::Stat { mt, path } => cmd::stat(&mt, &path),
-        Cmd::Cat { mt, path } => cmd::cat(&mt, &path),
+        Cmd::Cat { mt, path, offset, length } => cmd::cat(&mt, &path, offset, length),
         Cmd::Tree { mt, max_depth } => cmd::tree(&mt, max_depth),
         Cmd::Parts { image } => cmd::parts(&image),
         Cmd::Audit {

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -79,6 +79,11 @@ impl Mount {
         }
     }
 
+    #[cfg(not(all(windows, feature = "mount")))]
+    pub fn open_rw(mt: &MountArgs) -> Result<Self> {
+        Self::open(mt)
+    }
+
     /// RW analogue of [`open_direct`] — uses `fs_ext4_mount_rw` against the
     /// device path. Available so `--rw` works without a `--part`.
     #[cfg(all(windows, feature = "mount"))]
@@ -445,7 +450,10 @@ mod winfsp_adapter {
             if let Ok(cn) = CString::new(&buffer[name_start..name_end]) {
                 let value = &buffer[val_start..val_end];
                 if val_len == 0 {
-                    unsafe { fs_ext4_removexattr(fs, cp.as_ptr(), cn.as_ptr()) };
+                    let rc = unsafe { fs_ext4_removexattr(fs, cp.as_ptr(), cn.as_ptr()) };
+                    if rc != 0 {
+                        return Err(errno_to_status(unsafe { fs_ext4_last_errno() }).into());
+                    }
                 } else {
                     let rc = unsafe {
                         fs_ext4_setxattr(
@@ -730,6 +738,15 @@ mod winfsp_adapter {
             let path = context.unix_path();
             let attr = stat_path(self.mount.fs, &path)?;
             populate_file_info(&attr, file_info);
+            // Probe xattr presence so Windows issues QueryEa when EAs exist.
+            if let Ok(cp) = CString::new(path.as_str()) {
+                let n = unsafe {
+                    fs_ext4_listxattr(self.mount.fs, cp.as_ptr(), std::ptr::null_mut(), 0)
+                };
+                if n > 0 {
+                    file_info.ea_size = n as u32;
+                }
+            }
             *context.size.lock().unwrap() = attr.size;
             *context.attr.lock().unwrap() = attr;
             Ok(())

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -368,12 +368,12 @@ mod winfsp_adapter {
     use winfsp::host::{FileSystemHost, FileSystemParams, OperationGuardStrategy, VolumeParams};
     use winfsp::host::DebugMode;
     use windows::Win32::Foundation::{
-        STATUS_ACCESS_DENIED, STATUS_DIRECTORY_NOT_EMPTY, STATUS_DISK_FULL, STATUS_END_OF_FILE,
-        STATUS_FILE_IS_A_DIRECTORY, STATUS_FILE_TOO_LARGE, STATUS_INSUFFICIENT_RESOURCES,
-        STATUS_INVALID_DEVICE_REQUEST, STATUS_INVALID_PARAMETER, STATUS_IO_DEVICE_ERROR,
-        STATUS_MEDIA_WRITE_PROTECTED, STATUS_NAME_TOO_LONG, STATUS_NOT_A_DIRECTORY,
-        STATUS_NOT_IMPLEMENTED, STATUS_NOT_SUPPORTED, STATUS_OBJECT_NAME_COLLISION,
-        STATUS_OBJECT_NAME_NOT_FOUND,
+        STATUS_ACCESS_DENIED, STATUS_BUFFER_OVERFLOW, STATUS_DIRECTORY_NOT_EMPTY,
+        STATUS_DISK_FULL, STATUS_END_OF_FILE, STATUS_FILE_IS_A_DIRECTORY, STATUS_FILE_TOO_LARGE,
+        STATUS_INSUFFICIENT_RESOURCES, STATUS_INVALID_DEVICE_REQUEST, STATUS_INVALID_PARAMETER,
+        STATUS_IO_DEVICE_ERROR, STATUS_MEDIA_WRITE_PROTECTED, STATUS_NAME_TOO_LONG,
+        STATUS_NOT_A_DIRECTORY, STATUS_NOT_IMPLEMENTED, STATUS_NOT_SUPPORTED,
+        STATUS_OBJECT_NAME_COLLISION, STATUS_OBJECT_NAME_NOT_FOUND, STATUS_UNSUCCESSFUL,
     };
     use windows::Win32::Storage::FileSystem::{
         FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_READONLY,
@@ -1185,6 +1185,198 @@ mod winfsp_adapter {
             Ok(())
         }
 
+        // ---------------------------------------------------------------------------
+        // Extended Attributes (EAs) — ext4 xattrs exposed through WinFsp
+        //
+        // Mapping: we use the full xattr name (including namespace prefix like
+        // "user.") as the EA name. This preserves round-trip fidelity — a Linux
+        // tool that writes "user.color" sees the same name from Windows.
+        // Windows EA names are treated as opaque bytes; case is preserved.
+        // ---------------------------------------------------------------------------
+
+        fn get_extended_attributes(
+            &self,
+            context: &Self::FileContext,
+            buffer: &mut [u8],
+        ) -> FspResult<u32> {
+            let path = context.unix_path();
+            let Ok(cp) = CString::new(path.as_str()) else {
+                return Err(STATUS_OBJECT_NAME_NOT_FOUND.into());
+            };
+
+            // Probe xattr name list size.
+            let list_size = unsafe {
+                fs_ext4_listxattr(self.mount.fs, cp.as_ptr(), std::ptr::null_mut(), 0)
+            };
+            if list_size < 0 || list_size == 0 {
+                return Ok(0);
+            }
+
+            let mut list_buf = vec![0u8; list_size as usize];
+            let n = unsafe {
+                fs_ext4_listxattr(
+                    self.mount.fs,
+                    cp.as_ptr(),
+                    list_buf.as_mut_ptr() as *mut std::os::raw::c_char,
+                    list_buf.len(),
+                )
+            };
+            if n <= 0 {
+                return Ok(0);
+            }
+
+            // Collect NUL-separated names.
+            let mut names: Vec<Vec<u8>> = Vec::new();
+            let mut pos = 0usize;
+            while pos < n as usize {
+                let end = list_buf[pos..].iter().position(|&b| b == 0).unwrap_or(n as usize - pos);
+                if end == 0 {
+                    break;
+                }
+                names.push(list_buf[pos..pos + end].to_vec());
+                pos += end + 1;
+            }
+
+            let mut out_pos = 0usize;
+            let count = names.len();
+            for (i, name_bytes) in names.iter().enumerate() {
+                let Ok(cn) = CString::new(name_bytes.as_slice()) else {
+                    continue;
+                };
+
+                // Probe value size.
+                let val_size = unsafe {
+                    fs_ext4_getxattr(
+                        self.mount.fs,
+                        cp.as_ptr(),
+                        cn.as_ptr(),
+                        std::ptr::null_mut(),
+                        0,
+                    )
+                };
+                if val_size < 0 {
+                    continue;
+                }
+
+                let mut val_buf = vec![0u8; val_size as usize];
+                let val_n = unsafe {
+                    fs_ext4_getxattr(
+                        self.mount.fs,
+                        cp.as_ptr(),
+                        cn.as_ptr(),
+                        val_buf.as_mut_ptr() as *mut c_void,
+                        val_buf.len(),
+                    )
+                };
+                if val_n < 0 {
+                    continue;
+                }
+                let value = &val_buf[..val_n as usize];
+
+                let ea_name_len = name_bytes.len(); // NOT including NUL
+                let ea_val_len = value.len();
+                // Header = 8 bytes; name field = ea_name_len + 1 (NUL); then value.
+                let raw_size = 8 + ea_name_len + 1 + ea_val_len;
+                let is_last = i == count - 1;
+                // Each entry aligned to 4 bytes except (optionally) the last.
+                let padded_size = if is_last { raw_size } else { (raw_size + 3) & !3 };
+
+                if out_pos + padded_size > buffer.len() {
+                    return Err(STATUS_BUFFER_OVERFLOW.into());
+                }
+
+                let entry = &mut buffer[out_pos..];
+                let next_offset = if is_last { 0u32 } else { padded_size as u32 };
+                entry[0..4].copy_from_slice(&next_offset.to_le_bytes());
+                entry[4] = 0; // Flags
+                entry[5] = ea_name_len as u8;
+                entry[6..8].copy_from_slice(&(ea_val_len as u16).to_le_bytes());
+                entry[8..8 + ea_name_len].copy_from_slice(name_bytes);
+                entry[8 + ea_name_len] = 0; // NUL terminator
+                if ea_val_len > 0 {
+                    entry[8 + ea_name_len + 1..8 + ea_name_len + 1 + ea_val_len]
+                        .copy_from_slice(value);
+                }
+                out_pos += padded_size;
+            }
+
+            Ok(out_pos as u32)
+        }
+
+        fn set_extended_attributes(
+            &self,
+            context: &Self::FileContext,
+            buffer: &[u8],
+            file_info: &mut FileInfo,
+        ) -> FspResult<()> {
+            self.ensure_writable()?;
+
+            let path = context.unix_path();
+            let Ok(cp) = CString::new(path.as_str()) else {
+                return Err(STATUS_OBJECT_NAME_NOT_FOUND.into());
+            };
+
+            let mut pos = 0usize;
+            loop {
+                if pos + 8 > buffer.len() {
+                    break;
+                }
+                let next_offset =
+                    u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap()) as usize;
+                let name_len = buffer[pos + 5] as usize;
+                let val_len =
+                    u16::from_le_bytes(buffer[pos + 6..pos + 8].try_into().unwrap()) as usize;
+
+                let name_start = pos + 8;
+                let name_end = name_start + name_len;
+                let val_start = name_end + 1; // skip NUL terminator
+                let val_end = val_start + val_len;
+
+                if val_end > buffer.len() {
+                    break;
+                }
+
+                let name_bytes = &buffer[name_start..name_end];
+                let value = &buffer[val_start..val_end];
+
+                if let Ok(cn) = CString::new(name_bytes) {
+                    if val_len == 0 {
+                        // Zero-length value means delete the attribute.
+                        unsafe { fs_ext4_removexattr(self.mount.fs, cp.as_ptr(), cn.as_ptr()) };
+                    } else {
+                        let rc = unsafe {
+                            fs_ext4_setxattr(
+                                self.mount.fs,
+                                cp.as_ptr(),
+                                cn.as_ptr(),
+                                value.as_ptr() as *const c_void,
+                                value.len(),
+                            )
+                        };
+                        if rc != 0 {
+                            let errno = unsafe { fs_ext4_last_errno() };
+                            return Err(errno_to_status(errno).into());
+                        }
+                    }
+                }
+
+                if next_offset == 0 {
+                    break;
+                }
+                pos += next_offset;
+            }
+
+            // Refresh file_info after EA mutation.
+            if let Ok(attr) = stat_path(self.mount.fs, &path) {
+                populate_file_info(&attr, file_info);
+                *context.attr.lock().unwrap() = attr;
+            } else {
+                return Err(STATUS_UNSUCCESSFUL.into());
+            }
+
+            Ok(())
+        }
+
         // Called by WinFsp for exact-filename directory queries (e.g.
         // FindFirstFile("Z:\some-name")) when pass_query_directory_filename
         // is set. Avoids the broken FSD pattern-matching path for non-wildcard
@@ -1256,6 +1448,7 @@ mod winfsp_adapter {
             .case_preserved_names(true)
             .unicode_on_disk(true)
             .pass_query_directory_filename(true)
+            .extended_attributes(true)
             .filesystem_name("ext4");
         // Default: read-only volume. Drop the flag for `--rw` mounts so
         // WinFsp dispatches mutating ops to our `create`/`write`/etc.

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -407,6 +407,13 @@ mod winfsp_adapter {
         (FILETIME_EPOCH_OFFSET_SEC.saturating_add(secs as u64)).saturating_mul(10_000_000)
     }
 
+    /// Convert a unix timestamp with nanosecond precision to FILETIME.
+    /// FILETIME resolution is 100 ns; we round nsec down to the nearest 100 ns.
+    fn unix_to_filetime_nsec(secs: u32, nsec: u32) -> u64 {
+        let base = (FILETIME_EPOCH_OFFSET_SEC.saturating_add(secs as u64)).saturating_mul(10_000_000);
+        base.saturating_add((nsec / 100) as u64)
+    }
+
     /// Apply a `FILE_FULL_EA_INFORMATION` buffer to `path` on `fs`.
     ///
     /// Parses the linked-list of EA entries and calls `fs_ext4_setxattr` for
@@ -491,10 +498,14 @@ mod winfsp_adapter {
         info.file_size = attr.size;
         // Allocation size: round up to 4 KiB, fine for an RO surface.
         info.allocation_size = (attr.size + 4095) & !4095;
-        info.creation_time = unix_to_filetime(attr.crtime.max(attr.mtime));
-        info.last_access_time = unix_to_filetime(attr.atime);
-        info.last_write_time = unix_to_filetime(attr.mtime);
-        info.change_time = unix_to_filetime(attr.ctime);
+        // Use sub-second precision where available (crtime_nsec / mtime_nsec may
+        // be 0 on old ext2/3 inodes; the fallback in fill_attr zeros the nsec fields).
+        let ct = unix_to_filetime_nsec(attr.crtime, attr.crtime_nsec)
+            .max(unix_to_filetime_nsec(attr.mtime, attr.mtime_nsec));
+        info.creation_time = ct;
+        info.last_access_time = unix_to_filetime_nsec(attr.atime, attr.atime_nsec);
+        info.last_write_time = unix_to_filetime_nsec(attr.mtime, attr.mtime_nsec);
+        info.change_time = unix_to_filetime_nsec(attr.ctime, attr.ctime_nsec);
         info.index_number = attr.inode as u64;
         info.hard_links = attr.link_count as u32;
         info.ea_size = 0;

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -440,7 +440,7 @@ mod winfsp_adapter {
         info.last_write_time = unix_to_filetime(attr.mtime);
         info.change_time = unix_to_filetime(attr.ctime);
         info.index_number = attr.inode as u64;
-        info.hard_links = 0;
+        info.hard_links = attr.link_count as u32;
         info.ea_size = 0;
     }
 
@@ -1030,17 +1030,21 @@ mod winfsp_adapter {
             let path = context.unix_path();
             let cp = CString::new(path.as_str())
                 .map_err(|_| windows::core::Error::from(STATUS_OBJECT_NAME_NOT_FOUND))?;
-            let atime_sec = filetime_to_unix(last_access_time).unwrap_or(KEEP_UNCHANGED);
-            let mtime_sec = filetime_to_unix(last_write_time).unwrap_or(KEEP_UNCHANGED);
+            let (atime_sec, atime_nsec) = filetime_to_unix_nsec(last_access_time)
+                .map(|(s, n)| (s, n))
+                .unwrap_or((KEEP_UNCHANGED, 0));
+            let (mtime_sec, mtime_nsec) = filetime_to_unix_nsec(last_write_time)
+                .map(|(s, n)| (s, n))
+                .unwrap_or((KEEP_UNCHANGED, 0));
             if atime_sec != KEEP_UNCHANGED || mtime_sec != KEEP_UNCHANGED {
                 let rc = unsafe {
                     fs_ext4_utimens(
                         self.mount.fs,
                         cp.as_ptr(),
                         atime_sec,
-                        0,
+                        atime_nsec,
                         mtime_sec,
-                        0,
+                        mtime_nsec,
                     )
                 };
                 if rc != 0 {
@@ -1407,10 +1411,10 @@ mod winfsp_adapter {
         }
     }
 
-    /// FILETIME (100-ns since 1601) → Unix-seconds. Returns `None` for
-    /// 0 (WinFsp's "leave unchanged" sentinel) and for FILETIMEs that
-    /// predate the Unix epoch (clamped to `None` rather than wrapping).
-    fn filetime_to_unix(ft: u64) -> Option<u32> {
+    /// FILETIME (100-ns since 1601) → (Unix seconds, sub-second nanoseconds).
+    /// Returns `None` for 0 (WinFsp's "leave unchanged" sentinel) and for
+    /// FILETIMEs that predate the Unix epoch.
+    fn filetime_to_unix_nsec(ft: u64) -> Option<(u32, u32)> {
         if ft == 0 {
             return None;
         }
@@ -1419,13 +1423,16 @@ mod winfsp_adapter {
             return None;
         }
         let unix = secs_since_1601 - FILETIME_EPOCH_OFFSET_SEC;
+        let nsec = ((ft % 10_000_000) * 100) as u32;
         if unix > u32::MAX as u64 {
-            // Beyond Y2038 (in unix32 land). We pass through the high
-            // bits anyway — the C ABI takes u32 and ext4 either truncates
-            // or stores extra precision via xattrs. For v1 just clamp.
-            return Some(u32::MAX - 1);
+            return Some((u32::MAX - 1, 0));
         }
-        Some(unix as u32)
+        Some((unix as u32, nsec))
+    }
+
+    /// FILETIME → Unix seconds only (convenience wrapper used by read paths).
+    fn filetime_to_unix(ft: u64) -> Option<u32> {
+        filetime_to_unix_nsec(ft).map(|(s, _)| s)
     }
 
     /// Mount the given ext4 source on a Windows mount point.

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -407,6 +407,62 @@ mod winfsp_adapter {
         (FILETIME_EPOCH_OFFSET_SEC.saturating_add(secs as u64)).saturating_mul(10_000_000)
     }
 
+    /// Apply a `FILE_FULL_EA_INFORMATION` buffer to `path` on `fs`.
+    ///
+    /// Parses the linked-list of EA entries and calls `fs_ext4_setxattr` for
+    /// each non-empty entry, or `fs_ext4_removexattr` for zero-length entries.
+    /// Skips entries whose names contain NUL bytes (malformed); returns the
+    /// first `fs_ext4_setxattr` error, if any.
+    fn apply_ea_buffer(
+        fs: *mut fs_ext4_fs_t,
+        cp: &CString,
+        buffer: &[u8],
+    ) -> FspResult<()> {
+        let mut pos = 0usize;
+        loop {
+            if pos + 8 > buffer.len() {
+                break;
+            }
+            let next_offset =
+                u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap()) as usize;
+            let name_len = buffer[pos + 5] as usize;
+            let val_len =
+                u16::from_le_bytes(buffer[pos + 6..pos + 8].try_into().unwrap()) as usize;
+            let name_start = pos + 8;
+            let name_end = name_start + name_len;
+            let val_start = name_end + 1;
+            let val_end = val_start + val_len;
+            if val_end > buffer.len() {
+                break;
+            }
+            if let Ok(cn) = CString::new(&buffer[name_start..name_end]) {
+                let value = &buffer[val_start..val_end];
+                if val_len == 0 {
+                    unsafe { fs_ext4_removexattr(fs, cp.as_ptr(), cn.as_ptr()) };
+                } else {
+                    let rc = unsafe {
+                        fs_ext4_setxattr(
+                            fs,
+                            cp.as_ptr(),
+                            cn.as_ptr(),
+                            value.as_ptr() as *const c_void,
+                            value.len(),
+                        )
+                    };
+                    if rc != 0 {
+                        let errno = unsafe { fs_ext4_last_errno() };
+                        return Err(errno_to_status(errno).into());
+                    }
+                }
+            }
+            if next_offset == 0 {
+                break;
+            }
+            pos += next_offset;
+        }
+        Ok(())
+    }
+
     /// `\foo\bar` (UTF-16) → `/foo/bar` (UTF-8). The empty path becomes "/".
     fn winpath_to_unix(name: &U16CStr) -> Result<String> {
         let s = name.to_string().context("path is invalid UTF-16")?;
@@ -873,6 +929,13 @@ mod winfsp_adapter {
                 return Err(errno_to_status(errno).into());
             }
 
+            // Apply any EA data the caller supplied at creation time.
+            if let Some(ea) = _extra_buffer {
+                if !_extra_buffer_is_reparse_point {
+                    apply_ea_buffer(self.mount.fs, &cp, ea)?;
+                }
+            }
+
             let attr = stat_path(self.mount.fs, &unix_path)?;
             populate_file_info(&attr, file_info.as_mut());
             Ok(Ext4FileContext {
@@ -1320,55 +1383,7 @@ mod winfsp_adapter {
                 return Err(STATUS_OBJECT_NAME_NOT_FOUND.into());
             };
 
-            let mut pos = 0usize;
-            loop {
-                if pos + 8 > buffer.len() {
-                    break;
-                }
-                let next_offset =
-                    u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap()) as usize;
-                let name_len = buffer[pos + 5] as usize;
-                let val_len =
-                    u16::from_le_bytes(buffer[pos + 6..pos + 8].try_into().unwrap()) as usize;
-
-                let name_start = pos + 8;
-                let name_end = name_start + name_len;
-                let val_start = name_end + 1; // skip NUL terminator
-                let val_end = val_start + val_len;
-
-                if val_end > buffer.len() {
-                    break;
-                }
-
-                let name_bytes = &buffer[name_start..name_end];
-                let value = &buffer[val_start..val_end];
-
-                if let Ok(cn) = CString::new(name_bytes) {
-                    if val_len == 0 {
-                        // Zero-length value means delete the attribute.
-                        unsafe { fs_ext4_removexattr(self.mount.fs, cp.as_ptr(), cn.as_ptr()) };
-                    } else {
-                        let rc = unsafe {
-                            fs_ext4_setxattr(
-                                self.mount.fs,
-                                cp.as_ptr(),
-                                cn.as_ptr(),
-                                value.as_ptr() as *const c_void,
-                                value.len(),
-                            )
-                        };
-                        if rc != 0 {
-                            let errno = unsafe { fs_ext4_last_errno() };
-                            return Err(errno_to_status(errno).into());
-                        }
-                    }
-                }
-
-                if next_offset == 0 {
-                    break;
-                }
-                pos += next_offset;
-            }
+            apply_ea_buffer(self.mount.fs, &cp, buffer)?;
 
             // Refresh file_info after EA mutation.
             if let Ok(attr) = stat_path(self.mount.fs, &path) {


### PR DESCRIPTION
## Summary

- **Full write CLI** — `write`, `mkdir`, `rmdir`, `unlink`, `truncate`, `rename`, `touch`, `chmod`, `chown`; `write` creates file if missing
- **`setxattr` / `removexattr` / `symlink` / `link`** — extended attribute write and hard/soft link creation
- **`setflags`** — `FS_IOC_SETFLAGS` wrapper
- **`mknod`** — special file creation (FIFOs, sockets, char/block devices)
- **`fallocate`** — preallocate, punch-hole, zero-range
- **`cat --offset / --length`** — partial file reads
- **`stat` improvements** — mode string, UTC timestamps
- **xattrs as Windows EAs** — mount layer exposes ext4 xattrs via `get/set_extended_attributes`; EA buffer wired at file creation
- **`fs_ext4_attr_t` extension** — nsec timestamps, `inode_flags`, `generation`, `blocks_512`; `stat` and mount use them
- **Sub-second timestamp precision** — mount layer accurate `hard_links` count fix
- **Library bumps** — rust-fs-ext4 through `ce55e99` (mknod, casefold, deep-dir extents, attr extension)

## Test plan

- [ ] Run full test matrix (`./scripts/run-matrix.sh`) against ARM64 Windows VM
- [ ] Verify write CLI ops: write, mkdir, rmdir, unlink, truncate, rename, touch, chmod, chown
- [ ] Verify xattr round-trip: setxattr → getxattr → removexattr
- [ ] Verify mknod creates FIFOs and devices; fallocate preallocates correctly
- [ ] Verify EAs visible from Windows side after mount