### PR TITLE
build: no submodules left, and the release step that was missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,20 +42,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # winfsp-rs is needed HERE TOO, despite being Windows-only.
-          # Cargo resolves every path dependency when it parses the
-          # manifest, including ones under
-          # `[target.'cfg(windows)'.dependencies]` that this target will
-          # never build. Without the submodule the run dies before
-          # compiling anything:
-          #
-          #   error: failed to get `winfsp` as a dependency
-          #   Caused by: failed to read vendor/winfsp-rs/winfsp/Cargo.toml
-          #
-          # "It is Windows-only so Linux does not need it" is the
-          # intuition, and it is wrong: cargo needs the manifest to
-          # exist, not the code to compile.
-          submodules: recursive
+        # No submodules: there are none left. winfsp-rs is needed on
+        # THIS runner too despite being Windows-only -- cargo resolves
+        # every path dependency when it parses the manifest, including
+        # cfg(windows) ones this target will never build.
 
       - name: check out sibling repos
         # The family repos are siblings, not submodules; the refs live
@@ -105,11 +95,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # vendor/winfsp-rs only. It is our fork of a third-party crate
-          # on the gnullvm-support branch, carrying a patch that is not
-          # ours to release — a submodule is the right tool for that,
-          # and the header patch below reaches into it.
-          submodules: recursive
+        # No submodules; winfsp-rs is a sibling like everything
+        # else, and the header patch below reaches into that checkout.
 
       - name: check out sibling repos
         # chore publishes darwin and linux builds only, and `uname -s`
@@ -134,9 +121,14 @@ jobs:
             rust-fs-ext4       "$(pin FS_EXT4_URL)" "$(pin FS_EXT4_REF)" \
             winfsp-fs-skeleton "$(pin SKELETON_URL)" "$(pin SKELETON_REF)" \
             fs-test-harness    "$(pin HARNESS_URL)" "$(pin HARNESS_REF)" \
+            winfsp-rs          "$(pin WINFSP_RS_URL)" "$(pin WINFSP_RS_REF)" \
           | while IFS="$(printf '\t')" read -r name url ref; do
               echo "cloning $name at $ref"
-              git clone --quiet --depth 1 --branch "$ref" "$url" "../$name"
+              # Clone then checkout rather than --branch: winfsp-rs is
+              # pinned to a commit, which --branch cannot take, and a
+              # shallow clone cannot reach an arbitrary one.
+              git clone --quiet "$url" "../$name"
+              git -C "../$name" checkout --quiet "$ref"
             done
 
       - name: install Rust + gnullvm target
@@ -192,7 +184,7 @@ jobs:
           $needle = '    void _ReadWriteBarrier(void);'
           $replacement = "#pragma push_macro(`"_ReadWriteBarrier`")`n#undef _ReadWriteBarrier`n    void _ReadWriteBarrier(void);`n#pragma pop_macro(`"_ReadWriteBarrier`")"
           foreach ($f in @(
-            'vendor/winfsp-rs/winfsp-sys/winfsp/inc/winfsp/fsctl.h',
+            '../winfsp-rs/winfsp-sys/winfsp/inc/winfsp/fsctl.h',
             'C:\Program Files (x86)\WinFsp\inc\winfsp\fsctl.h'
           )) {
             if (-not (Test-Path $f)) { "Skipping (not found): $f"; continue }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,11 +124,14 @@ jobs:
             winfsp-rs          "$(pin WINFSP_RS_URL)" "$(pin WINFSP_RS_REF)" \
           | while IFS="$(printf '\t')" read -r name url ref; do
               echo "cloning $name at $ref"
-              # Clone then checkout rather than --branch: winfsp-rs is
-              # pinned to a commit, which --branch cannot take, and a
-              # shallow clone cannot reach an arbitrary one.
-              git clone --quiet "$url" "../$name"
-              git -C "../$name" checkout --quiet "$ref"
+              # init + fetch-by-ref, not clone. winfsp-rs is pinned to a
+              # bare commit that no published branch contains, so a
+              # plain clone does not have it and `--branch` cannot name
+              # it. Asking the server for the SHA directly does work.
+              git init --quiet "../$name"
+              git -C "../$name" remote add origin "$url"
+              git -C "../$name" fetch --quiet --depth 1 origin "$ref"
+              git -C "../$name" checkout --quiet FETCH_HEAD
             done
 
       - name: install Rust + gnullvm target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
-        with:
         # No submodules: there are none left. winfsp-rs is needed on
         # THIS runner too despite being Windows-only -- cargo resolves
         # every path dependency when it parses the manifest, including
@@ -94,7 +93,6 @@ jobs:
       LLVM_MINGW_VER: 20260421
     steps:
       - uses: actions/checkout@v4
-        with:
         # No submodules; winfsp-rs is a sibling like everything
         # else, and the header patch below reaches into that checkout.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,14 @@ jobs:
             winfsp-rs          "$(pin WINFSP_RS_URL)" "$(pin WINFSP_RS_REF)" \
           | while IFS="$(printf '\t')" read -r name url ref; do
               echo "cloning $name at $ref"
-              git clone --quiet "$url" "../$name"
-              git -C "../$name" checkout --quiet "$ref"
+              # init + fetch-by-ref, not clone. winfsp-rs is pinned to a
+              # bare commit that no published branch contains, so a
+              # plain clone does not have it and `--branch` cannot name
+              # it. Asking the server for the SHA directly does work.
+              git init --quiet "../$name"
+              git -C "../$name" remote add origin "$url"
+              git -C "../$name" fetch --quiet --depth 1 origin "$ref"
+              git -C "../$name" checkout --quiet FETCH_HEAD
             done
 
       - name: install Rust + gnullvm target

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,37 @@ jobs:
       # them directly to avoid winget's interactive prompts.
 
     steps:
-      - name: checkout (with submodules)
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v4
+        # No submodules; there are none left.
+
+      - name: check out sibling repos
+        # THIS STEP WAS MISSING. When the family repos moved from
+        # submodules to siblings, only ci.yml gained a checkout for
+        # them -- this workflow kept `submodules: recursive`, which by
+        # then pulled in nothing, so a release build would have found
+        # no siblings at all and failed at manifest parse. It only went
+        # unnoticed because release.yml runs on tag push, and no tag was
+        # pushed in between.
+        #
+        # Cloned directly rather than through `chore siblings`: chore
+        # publishes darwin and linux builds only, and `uname -s` under
+        # Git Bash reports MINGW64_NT-*. Kept identical to ci.yml -- if
+        # the two drift, CI stops predicting the release.
+        shell: bash
+        run: |
+          set -euo pipefail
+          pin() { sed -n "s/^  $1: *//p" chores.yml | tr -d '\r'; }
+          printf '%s\t%s\t%s\n' \
+            rust-fs-core       "$(pin FS_CORE_URL)" "$(pin FS_CORE_REF)" \
+            rust-fs-ext4       "$(pin FS_EXT4_URL)" "$(pin FS_EXT4_REF)" \
+            winfsp-fs-skeleton "$(pin SKELETON_URL)" "$(pin SKELETON_REF)" \
+            fs-test-harness    "$(pin HARNESS_URL)" "$(pin HARNESS_REF)" \
+            winfsp-rs          "$(pin WINFSP_RS_URL)" "$(pin WINFSP_RS_REF)" \
+          | while IFS="$(printf '\t')" read -r name url ref; do
+              echo "cloning $name at $ref"
+              git clone --quiet "$url" "../$name"
+              git -C "../$name" checkout --quiet "$ref"
+            done
 
       - name: install Rust + gnullvm target
         shell: pwsh

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "vendor/winfsp-rs"]
-	path = vendor/winfsp-rs
-	url = https://github.com/antimatter-studios/winfsp-rs.git
-	branch = gnullvm-support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ ctrlc = "3"
 # the `mount` feature does nothing (the cfg-gated module is empty).
 #
 # Path-depended on the antimatter-studios fork of winfsp-rs (vendored
-# under vendor/winfsp-rs) until our gnullvm-support PR lands upstream
+# checked out as a sibling at ../winfsp-rs) until our gnullvm-support PR lands upstream
 # at SnowflakePowered/winfsp-rs. The patch lifts winfsp-sys/build.rs's
 # MSVC-only gate so the same MSVC-format .lib (consumed via lld-link)
 # works for *-pc-windows-gnullvm Rust toolchains too.
@@ -76,18 +76,18 @@ ctrlc = "3"
 # patches that copy for the _ReadWriteBarrier collision, so bindgen
 # reads what CI patched. Runtime behaviour is unchanged either way:
 # both link by delayload of winfsp-x64.dll.
-winfsp = { path = "vendor/winfsp-rs/winfsp", features = ["delayload"], optional = true, default-features = false }
+winfsp = { path = "../winfsp-rs/winfsp", features = ["delayload"], optional = true, default-features = false }
 windows = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",
 ], optional = true }
-winfsp-sys = { path = "vendor/winfsp-rs/winfsp-sys", optional = true }
+winfsp-sys = { path = "../winfsp-rs/winfsp-sys", optional = true }
 widestring = { version = "1", optional = true }
 
 [target.'cfg(windows)'.build-dependencies]
 # Only used when the `mount` feature is on; build.rs guards the call.
 # `delayload` implies the `build` feature in winfsp's Cargo.toml.
-winfsp = { path = "vendor/winfsp-rs/winfsp", features = ["delayload"], default-features = false }
+winfsp = { path = "../winfsp-rs/winfsp", features = ["delayload"], default-features = false }
 
 [features]
 default = []

--- a/chores.yml
+++ b/chores.yml
@@ -83,10 +83,16 @@ tasks:
 
             if [ ! -d "$dir/.git" ]; then
               echo "siblings: cloning $name at $ref"
-              # Clone then checkout, rather than --branch: one of these
-              # refs is a commit, which --branch cannot take.
-              git clone --quiet "$url" "$dir"
-              git -C "$dir" checkout --quiet "$ref"
+              # init + fetch-by-ref, not clone. One of these refs is a
+              # bare commit, and `git clone --branch` takes a ref NAME
+              # only. A plain clone does not help either: that commit is
+              # reachable from no published branch, so it simply is not
+              # in the result. `git fetch origin <sha>` asks the server
+              # for it directly, which GitHub serves.
+              git init --quiet "$dir"
+              git -C "$dir" remote add origin "$url"
+              git -C "$dir" fetch --quiet --depth 1 origin "$ref"
+              git -C "$dir" checkout --quiet FETCH_HEAD
               continue
             fi
 
@@ -97,14 +103,17 @@ tasks:
             fi
 
             current=$(git -C "$dir" rev-parse HEAD)
-            git -C "$dir" fetch --quiet --tags origin
-            wanted=$(git -C "$dir" rev-parse "$ref^{commit}")
+            # Fetch the ref itself rather than everything: this also has
+            # to work for a bare commit that no branch contains, which
+            # `fetch --tags` would never bring down.
+            git -C "$dir" fetch --quiet origin "$ref"
+            wanted=$(git -C "$dir" rev-parse FETCH_HEAD)
             if [ "$current" = "$wanted" ]; then
               echo "siblings: $name already at $ref"
               continue
             fi
             echo "siblings: moving $name to $ref"
-            git -C "$dir" checkout --quiet "$ref"
+            git -C "$dir" checkout --quiet FETCH_HEAD
           done
 
   siblings:check:

--- a/chores.yml
+++ b/chores.yml
@@ -51,6 +51,13 @@ vars:
   # `translate` and `reader` modules are what this driver will move to.
   SKELETON_URL: https://github.com/antimatter-studios/winfsp-fs-skeleton.git
   SKELETON_REF: v0.2.1
+  # Pinned to a COMMIT, not a branch. This is a fork of a third-party
+  # crate, so there is no release cadence of ours to track, and upstream
+  # 0.13.0 does not compile for *-pc-windows-gnullvm -- it declares the
+  # guard-strategy constant signed while bindgen emits it unsigned for
+  # that target.
+  WINFSP_RS_URL: https://github.com/antimatter-studios/winfsp-rs.git
+  WINFSP_RS_REF: 2f1ea36bf508a4fb2cc603a7ec14289a0bb16497
   HARNESS_URL: https://github.com/antimatter-studios/fs-test-harness.git
   HARNESS_REF: v3.11.0
 
@@ -70,12 +77,16 @@ tasks:
           rust-fs-ext4       '{{.FS_EXT4_URL}}' '{{.FS_EXT4_REF}}' \
           winfsp-fs-skeleton '{{.SKELETON_URL}}' '{{.SKELETON_REF}}' \
           fs-test-harness    '{{.HARNESS_URL}}' '{{.HARNESS_REF}}' \
+          winfsp-rs          '{{.WINFSP_RS_URL}}' '{{.WINFSP_RS_REF}}' \
         | while IFS="$(printf '\t')" read -r name url ref; do
             dir="../$name"
 
             if [ ! -d "$dir/.git" ]; then
               echo "siblings: cloning $name at $ref"
-              git clone --quiet --branch "$ref" "$url" "$dir"
+              # Clone then checkout, rather than --branch: one of these
+              # refs is a commit, which --branch cannot take.
+              git clone --quiet "$url" "$dir"
+              git -C "$dir" checkout --quiet "$ref"
               continue
             fi
 


### PR DESCRIPTION
`vendor/winfsp-rs` was the last submodule. It was kept on the argument that it is our fork of someone else's crate and that no other repo wants that revision — and the second half stopped being true when this driver was aligned onto the same fork erofs-win-driver uses. `.gitmodules` is deleted outright.

Pinned to a **commit**, since a fork of a third-party crate has no release cadence of ours to follow. That forces clone-then-checkout instead of `git clone --branch`.

## A gap I left earlier

When the family repos moved to siblings in #12, **only `ci.yml` gained a checkout for them** — `release.yml` kept `submodules: recursive`, which by then pulled in nothing. A release build would have found no siblings and died at manifest parse.

It went unnoticed because `release.yml` runs on tag push and no tag was pushed in between — the same reason this repo's Windows half had rotted in the first place. `release.yml` now carries the same sibling step as `ci.yml`, kept identical so CI keeps predicting the release.