### PR TITLE
build: move to winfsp-rs 0.13.0, with the portability fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,7 +808,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winfsp"
-version = "0.12.4+winfsp-2.1"
+version = "0.13.0+winfsp-2.1"
 dependencies = [
  "bytemuck",
  "parking_lot",

--- a/chores.yml
+++ b/chores.yml
@@ -57,7 +57,7 @@ vars:
   # guard-strategy constant signed while bindgen emits it unsigned for
   # that target.
   WINFSP_RS_URL: https://github.com/antimatter-studios/winfsp-rs.git
-  WINFSP_RS_REF: 2f1ea36bf508a4fb2cc603a7ec14289a0bb16497
+  WINFSP_RS_REF: 59ab48bca2a67c95d4eba640343b6b80b87bb6ea
   HARNESS_URL: https://github.com/antimatter-studios/fs-test-harness.git
   HARNESS_REF: v3.11.0
 

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -384,7 +384,7 @@ mod winfsp_adapter {
     // Fine requires the context to be Sync while Coarse only needs Send.
     // Leaving it inferred picks FineGuard, which is what this driver was
     // asking for explicitly.
-    use winfsp::host::{FileSystemHost, FileSystemParams, VolumeParams};
+    use winfsp::host::{FileSystemHost, FileSystemParams, FineGuard, VolumeParams};
     use winfsp::Result as FspResult;
     use winfsp_sys::{FILE_ACCESS_RIGHTS, FILE_FLAGS_AND_ATTRIBUTES};
 
@@ -1501,7 +1501,17 @@ mod winfsp_adapter {
             params.read_only_volume(true);
         }
 
-        let mut host = FileSystemHost::new_with_options(
+        // The guard strategy is named rather than inferred. 0.13.0 has
+        // two impls whose methods collide when S is open -- a general
+        // one over any OperationGuardStrategy and a FineGuard-specific
+        // one requiring the context to be Sync -- so leaving it to
+        // inference is E0034, "multiple applicable items in scope", at
+        // the mount call rather than here.
+        //
+        // FineGuard is what this driver wants: WinFsp guards namespace
+        // operations with a read-write lock and leaves file I/O
+        // concurrent, so reads on different files do not serialise.
+        let mut host = FileSystemHost::<_, FineGuard>::new_with_options(
             FileSystemParams {
                 use_dir_info_by_name: true,
                 volume_params: params,

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -377,7 +377,14 @@ mod winfsp_adapter {
         OpenFileInfo, VolumeInfo, WideNameInfo,
     };
     use winfsp::host::DebugMode;
-    use winfsp::host::{FileSystemHost, FileSystemParams, OperationGuardStrategy, VolumeParams};
+    // The locking strategy is a TYPE PARAMETER on FileSystemHost in
+    // 0.13.0, not a field on FileSystemParams -- that is the change that
+    // "move guard strategy into types to prevent potential send/sync
+    // soundness issues" made, and the reason it is a parameter is that
+    // Fine requires the context to be Sync while Coarse only needs Send.
+    // Leaving it inferred picks FineGuard, which is what this driver was
+    // asking for explicitly.
+    use winfsp::host::{FileSystemHost, FileSystemParams, VolumeParams};
     use winfsp::Result as FspResult;
     use winfsp_sys::{FILE_ACCESS_RIGHTS, FILE_FLAGS_AND_ATTRIBUTES};
 
@@ -1498,13 +1505,6 @@ mod winfsp_adapter {
             FileSystemParams {
                 use_dir_info_by_name: true,
                 volume_params: params,
-                // Fine-grained locking: WinFsp guards namespace
-                // operations with a read-write lock and leaves file I/O
-                // concurrent, so reads on different files do not
-                // serialise. This is the strategy the crate defaults
-                // to, stated explicitly because it is a field here
-                // rather than a type parameter.
-                guard_strategy: OperationGuardStrategy::Fine,
                 debug_mode: DebugMode::none(),
             },
             ctx,


### PR DESCRIPTION
The pin was v0.12.4-1, chosen **only** because upstream 0.13.0 would not compile for `*-pc-windows-gnullvm`. That fallback cost this driver 0.13.0's soundness work: various unnoticed UB, a TOCTOU in `AtomicHandle`, a potential timer UAF, async IO ops completing after drop, and a worker thread not joined before drop.

## The bug

`OperationGuardStrategy::RAW` is declared `i32`, and bindgen emits the guard-strategy constants as `u32` for gnullvm — three E0308s inside the `winfsp` crate, before any consumer code is reached.

bindgen takes a C enum's constant signedness from the headers as *that target's* clang sees them, and msvc and gnullvm disagree. So does `FspFileSystemSetOperationGuardStrategyF`'s own parameter. **Naming either concrete type breaks the other target** — this isn't a case of picking the right one.

`antimatter-studios/winfsp-rs` now carries a `gnullvm-0.13.0` branch: 0.13.0 plus a target-independent fix. `RAW` becomes `u32` with an `as` cast at each definition and `as _` at the call — an identity conversion where the types already agree, a reinterpretation where they don't, and exact either way for two small non-negative constants.

Worth offering upstream: it's a genuine portability bug in their release, and the fix isn't gnullvm-specific.

Whether it actually builds is a question only the Windows job can answer.